### PR TITLE
Register Slack users without recent messages

### DIFF
--- a/data/employees.json
+++ b/data/employees.json
@@ -1983,5 +1983,53 @@
       ]
     },
     "slack_synced_at": "2026-04-20T03:39:00.659Z"
+  },
+  {
+    "name": "Jun Akiyama",
+    "slack_id": "U0AD4UADJ07",
+    "job": "Other",
+    "createdAt": "2026-05-26T14:35:00.000Z",
+    "updatedAt": "2026-05-26T14:35:00.000Z",
+    "isActive": true
+  },
+  {
+    "name": "Nakaoka Koshiro",
+    "slack_id": "U0B40MREQM6",
+    "job": "Other",
+    "createdAt": "2026-05-26T14:35:00.000Z",
+    "updatedAt": "2026-05-26T14:35:00.000Z",
+    "isActive": true
+  },
+  {
+    "name": "Yukinko N0319",
+    "slack_id": "U09MSTQ6HQC",
+    "job": "Other",
+    "createdAt": "2026-05-26T14:35:00.000Z",
+    "updatedAt": "2026-05-26T14:35:00.000Z",
+    "isActive": true
+  },
+  {
+    "name": "上原基臣",
+    "slack_id": "U0AFQUQ1H9R",
+    "job": "Other",
+    "createdAt": "2026-05-26T14:35:00.000Z",
+    "updatedAt": "2026-05-26T14:35:00.000Z",
+    "isActive": true
+  },
+  {
+    "name": "真栄城則明",
+    "slack_id": "U0AGC56822X",
+    "job": "Other",
+    "createdAt": "2026-05-26T14:35:00.000Z",
+    "updatedAt": "2026-05-26T14:35:00.000Z",
+    "isActive": true
+  },
+  {
+    "name": "八木橋 雄一",
+    "slack_id": "U0AG0UR6LDA",
+    "job": "Other",
+    "createdAt": "2026-05-26T14:35:00.000Z",
+    "updatedAt": "2026-05-26T14:35:00.000Z",
+    "isActive": true
   }
 ]


### PR DESCRIPTION
## Overview
- Registers 6 Primary Workspace Slack users who were unregistered and had no messages in the discovery window.
- Adds them with Slack IDs and Other as the initial job placeholder.
- Leaves generated docs/graph untouched so the existing sync/generation pipeline can update derived artifacts.

## Branch / PR Strategy
- Base branch: main
- Working branch: codex/register-unmessaged-slack-users-20260526
- PR size budget: small data-only change, well under 300 changed lines
- Split criteria: message-bearing candidates and secondary workspace IDs remain separate follow-up work

## Verification
- employees.json JSON parse check passed
- git diff --check passed
- Confirmed employee count is 22 active records and no duplicate primary Slack IDs.

## Notes
- Registered users: Jun Akiyama, Nakaoka Koshiro, Yukinko N0319, 上原基臣, 真栄城則明, 八木橋 雄一.
- Temporary discovery workflow was reverted from main before this PR.
