### PR TITLE
Slack社員検索向けの検索facet生成を追加

### DIFF
--- a/.github/workflows/slack-sync-cron.yml
+++ b/.github/workflows/slack-sync-cron.yml
@@ -49,6 +49,9 @@ jobs:
           GCP_LOCATION: ${{ secrets.GCP_LOCATION || 'us-central1' }}
           GCP_ENDPOINT_ID: ${{ secrets.GCP_ENDPOINT_ID }}
 
+      - name: Build Search Facets
+        run: node scripts/build-search-facets.js
+
       - name: Generate Graph Documentation
         run: node scripts/generate-graph-doc.js
 
@@ -56,5 +59,5 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add data/employees.json data/knowledge-graph.json docs/TEAM.md docs/KNOWLEDGE_GRAPH.md docs/index.html
-          git diff --quiet && git diff --staged --quiet || (git commit -m "Auto: Update employee profiles and knowledge graph" && git push)
+          git add data/employees.json data/knowledge-graph.json data/search-facets.jsonld data/slack-messages.jsonl docs/TEAM.md docs/KNOWLEDGE_GRAPH.md docs/index.html
+          git diff --quiet && git diff --staged --quiet || (git commit -m "Auto: Update employee profiles, search facets, and knowledge graph" && git push)

--- a/.github/workflows/update-employee-data.yml
+++ b/.github/workflows/update-employee-data.yml
@@ -48,6 +48,9 @@ jobs:
           GCP_LOCATION: ${{ secrets.GCP_LOCATION || 'us-central1' }}
           GCP_ENDPOINT_ID: ${{ secrets.GCP_ENDPOINT_ID }}
 
+      - name: Build Search Facets
+        run: node scripts/build-search-facets.js
+
       - name: Generate Graph Documentation
         run: node scripts/generate-graph-doc.js
 
@@ -55,11 +58,11 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/employees.json data/knowledge-graph.json docs/TEAM.md docs/KNOWLEDGE_GRAPH.md docs/index.html .github/ISSUE_TEMPLATE/2_delete_employee.yml
+          git add data/employees.json data/knowledge-graph.json data/search-facets.jsonld docs/TEAM.md docs/KNOWLEDGE_GRAPH.md docs/index.html .github/ISSUE_TEMPLATE/2_delete_employee.yml
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Update employee data from Issue #${{ github.event.issue.number }}"
+            git commit -m "Update employee data and search facets from Issue #${{ github.event.issue.number }}"
             git push
           fi
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "build:search-facets": "node scripts/build-search-facets.js",
+    "test:people-finder": "node scripts/test-people-finder-rag-search.js"
+  },
   "dependencies": {
     "@google-cloud/vertexai": "^1.10.0",
     "@google/generative-ai": "^0.24.1",

--- a/scripts/build-search-facets.js
+++ b/scripts/build-search-facets.js
@@ -1,0 +1,255 @@
+const fs = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, '../data');
+const EMPLOYEES_FILE = path.join(DATA_DIR, 'employees.json');
+const SLACK_MESSAGES_FILE = path.join(DATA_DIR, 'slack-messages.jsonl');
+const OUTPUT_FILE = path.join(DATA_DIR, 'search-facets.jsonld');
+
+const UI_CATEGORY_WORK = '仕事・相談';
+const UI_CATEGORY_PERSONAL = '興味・人柄';
+
+const CONTEXT = {
+  saiteki: 'https://saiteki.example/schema#',
+  person: 'saiteki:person',
+  uiCategory: 'saiteki:uiCategory',
+  category: 'saiteki:category',
+  label: 'saiteki:label',
+  aliases: 'saiteki:aliases',
+  evidence: 'saiteki:evidence',
+  messageQuotes: 'saiteki:messageQuotes',
+  sourceField: 'saiteki:sourceField'
+};
+
+const FIELD_CONFIGS = [
+  {
+    category: 'strength',
+    uiCategory: UI_CATEGORY_WORK,
+    path: 'work_styles_and_strengths.dominant_strengths',
+    evidencePath: 'work_styles_and_strengths.summary'
+  },
+  {
+    category: 'work_style',
+    uiCategory: UI_CATEGORY_WORK,
+    path: 'work_styles_and_strengths.problem_solving_style',
+    evidencePath: 'work_styles_and_strengths.summary'
+  },
+  {
+    category: 'work_topic',
+    uiCategory: UI_CATEGORY_WORK,
+    path: 'current_state.recent_topics_of_interest',
+    evidencePath: 'work_styles_and_strengths.summary',
+    filter: isWorkTopic
+  },
+  {
+    category: 'interest',
+    uiCategory: UI_CATEGORY_PERSONAL,
+    path: 'current_state.recent_topics_of_interest',
+    evidencePath: 'current_state.summary'
+  },
+  {
+    category: 'value',
+    uiCategory: UI_CATEGORY_PERSONAL,
+    path: 'values_and_motivators.core_values',
+    evidencePath: 'values_and_motivators.summary'
+  },
+  {
+    category: 'recent_topic',
+    uiCategory: UI_CATEGORY_PERSONAL,
+    path: 'values_and_motivators.motivation_triggers',
+    evidencePath: 'values_and_motivators.summary'
+  }
+];
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function readJsonl(file) {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function writeJsonl(file, rows) {
+  fs.writeFileSync(file, rows.map((row) => JSON.stringify(row)).join('\n') + (rows.length ? '\n' : ''));
+}
+
+function getPath(object, dottedPath) {
+  return dottedPath.split('.').reduce((value, key) => (value == null ? undefined : value[key]), object);
+}
+
+function toArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function cleanText(value, maxLength = 180) {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+}
+
+function isWorkTopic(value) {
+  return /ai|aws|react|next|rag|qa|pm|poc|gemini|cursor|notion|slack|api|db|sql|bi|開発|運用|監視|設計|要件|技術|テスト|品質|分析|採用|営業|総務|人事|オンボーディング|データ|プロンプト|自動化|インフラ|サーバ/i.test(value);
+}
+
+function normalizeText(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[・、。,.!?！？:：;；()[\]{}「」『』"']/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function makeAliases(label) {
+  const normalized = normalizeText(label);
+  const parts = normalized
+    .split(/[\s/／|、。・,，]+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length >= 2 && part !== normalized);
+  const ascii = normalized.match(/[a-z0-9+#.]{2,}/g) || [];
+  return [...new Set([...parts, ...ascii])].slice(0, 8);
+}
+
+function messageKey(message) {
+  return `${message.workspace || 'primary'}:${message.channelId || message.channel || ''}:${message.ts || message.messageTs || ''}`;
+}
+
+function normalizeSlackMessage(message, workspace = 'primary') {
+  const text = cleanText(message.text, 2000);
+  if (!message.user || !message.ts || !text) return null;
+  return {
+    id: messageKey({ ...message, workspace }),
+    workspace,
+    channelId: message.channelId || message.channel || '',
+    user: message.user,
+    text,
+    messageTs: String(message.ts),
+    threadTs: message.thread_ts ? String(message.thread_ts) : null,
+    parentUserId: message.parent_user_id || null,
+    permalink: message.permalink || null
+  };
+}
+
+function mergeSlackMessages(existingRows, fetchedMessages) {
+  const rowsById = new Map();
+  for (const row of existingRows) {
+    if (row && row.id) rowsById.set(row.id, row);
+  }
+  for (const message of fetchedMessages) {
+    const row = normalizeSlackMessage(message, message.workspace || 'primary');
+    if (row) rowsById.set(row.id, row);
+  }
+  return [...rowsById.values()].sort((a, b) => (a.messageTs || '').localeCompare(b.messageTs || ''));
+}
+
+function messagesBySlackId(messages) {
+  const index = new Map();
+  for (const message of messages) {
+    if (!message.user) continue;
+    if (!index.has(message.user)) index.set(message.user, []);
+    index.get(message.user).push(message);
+  }
+  return index;
+}
+
+function findMessageQuotes(employee, label, aliases, messageIndex) {
+  const ids = [employee.slack_id, employee.slack_id_2].filter(Boolean);
+  const terms = [label, ...aliases].map(normalizeText).filter((term) => term.length >= 2);
+  const quotes = [];
+
+  for (const id of ids) {
+    const messages = messageIndex.get(id) || [];
+    for (const message of messages) {
+      const text = normalizeText(message.text);
+      if (!terms.some((term) => text.includes(term))) continue;
+      quotes.push({
+        text: cleanText(message.text, 180),
+        channelId: message.channelId,
+        messageTs: message.messageTs,
+        threadTs: message.threadTs,
+        permalink: message.permalink
+      });
+      if (quotes.length >= 2) return quotes;
+    }
+  }
+
+  return quotes;
+}
+
+function buildSearchFacets(employees, slackMessages = []) {
+  const messageIndex = messagesBySlackId(slackMessages);
+  const graph = [];
+  const seen = new Set();
+
+  for (const employee of employees.filter((item) => item.isActive !== false)) {
+    for (const config of FIELD_CONFIGS) {
+      const values = toArray(getPath(employee, config.path));
+      const evidence = cleanText(getPath(employee, config.evidencePath) || employee.overall_summary || '');
+
+      for (const value of values) {
+        const label = cleanText(value, 120);
+        if (!label || label === '-') continue;
+        if (config.filter && !config.filter(label)) continue;
+
+        const key = `${employee.name}:${config.category}:${config.path}:${label}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        const aliases = makeAliases(label);
+        const messageQuotes = findMessageQuotes(employee, label, aliases, messageIndex);
+
+        graph.push({
+          '@id': `facet:${encodeURIComponent(employee.name)}:${config.category}:${graph.length + 1}`,
+          '@type': 'saiteki:SearchFacet',
+          person: `person:${employee.name}`,
+          employeeName: employee.name,
+          slackIds: [employee.slack_id, employee.slack_id_2].filter(Boolean),
+          uiCategory: config.uiCategory,
+          category: config.category,
+          label,
+          aliases,
+          evidence,
+          messageQuotes,
+          sourceField: config.path
+        });
+      }
+    }
+  }
+
+  return {
+    '@context': CONTEXT,
+    generatedAt: new Date().toISOString(),
+    sourceFiles: ['data/employees.json', 'data/slack-messages.jsonl'],
+    '@graph': graph
+  };
+}
+
+function writeSearchFacets(facets, outputFile = OUTPUT_FILE) {
+  fs.writeFileSync(outputFile, `${JSON.stringify(facets, null, 2)}\n`);
+}
+
+function main() {
+  const employees = readJson(EMPLOYEES_FILE);
+  const messages = readJsonl(SLACK_MESSAGES_FILE);
+  const facets = buildSearchFacets(employees, messages);
+  writeSearchFacets(facets);
+  console.log(`Generated ${facets['@graph'].length} search facets at ${OUTPUT_FILE}`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  buildSearchFacets,
+  mergeSlackMessages,
+  normalizeSlackMessage,
+  readJsonl,
+  writeJsonl,
+  writeSearchFacets
+};

--- a/scripts/people-finder-rag-search.js
+++ b/scripts/people-finder-rag-search.js
@@ -1,0 +1,225 @@
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_FACETS_FILE = path.join(__dirname, '../data/search-facets.jsonld');
+const UI_CATEGORY_WORK = '仕事・相談';
+const UI_CATEGORY_PERSONAL = '興味・人柄';
+const DEFAULT_THRESHOLD = 0.16;
+
+function normalizeText(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[・、。,.!?！？:：;；()[\]{}「」『』"']/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function stripQueryHelpers(query) {
+  return normalizeText(query)
+    .replace(/が好きな人|が好き|好きな人|好きな|興味がある人|詳しい人|得意な人|できる人|話せる人|相談できる人|相談したい|人/g, ' ')
+    .replace(/について|に関心がある|に興味がある|を探して|探して|教えて|詳しい|相談/g, ' ')
+    .replace(/([a-z0-9+#.])([^a-z0-9+#.\s])/g, '$1 $2')
+    .replace(/([^a-z0-9+#.\s])([a-z0-9+#.])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeCategory(category) {
+  const value = normalizeText(category);
+  if (['work', 'job', 'consult', '仕事', '相談', normalizeText(UI_CATEGORY_WORK)].includes(value)) {
+    return UI_CATEGORY_WORK;
+  }
+  if (['interest', 'personal', 'personality', '興味', '人柄', normalizeText(UI_CATEGORY_PERSONAL)].includes(value)) {
+    return UI_CATEGORY_PERSONAL;
+  }
+  return category;
+}
+
+function addNgrams(tokens, text, size) {
+  const chars = [...text.replace(/\s+/g, '')];
+  if (chars.length < size) return;
+  for (let index = 0; index <= chars.length - size; index++) {
+    tokens.push(chars.slice(index, index + size).join(''));
+  }
+}
+
+function tokenize(value) {
+  const normalized = normalizeText(value);
+  const tokens = [];
+  const words = normalized.split(/\s+/).filter((word) => word.length >= 2);
+  tokens.push(...words);
+  tokens.push(...(normalized.match(/[a-z0-9+#.]{2,}/g) || []));
+
+  const japaneseSegments = normalized
+    .replace(/[a-z0-9+#.]+/g, ' ')
+    .split(/\s+/)
+    .filter((segment) => segment.length >= 2);
+  for (const segment of japaneseSegments) {
+    addNgrams(tokens, segment, 2);
+    addNgrams(tokens, segment, 3);
+  }
+
+  return [...new Set(tokens)];
+}
+
+function vectorize(value) {
+  const vector = new Map();
+  for (const token of tokenize(value)) {
+    vector.set(token, (vector.get(token) || 0) + 1);
+  }
+  return vector;
+}
+
+function cosineSimilarity(a, b) {
+  let dot = 0;
+  let aNorm = 0;
+  let bNorm = 0;
+
+  for (const value of a.values()) aNorm += value * value;
+  for (const value of b.values()) bNorm += value * value;
+  for (const [key, value] of a.entries()) {
+    dot += value * (b.get(key) || 0);
+  }
+
+  if (!aNorm || !bNorm) return 0;
+  return dot / (Math.sqrt(aNorm) * Math.sqrt(bNorm));
+}
+
+function loadFacets(file = DEFAULT_FACETS_FILE) {
+  if (!fs.existsSync(file)) {
+    throw new Error(`Search facets file not found: ${file}. Run "npm run build:search-facets" first.`);
+  }
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  return data['@graph'] || [];
+}
+
+function scoreFacet(facet, queryVector, queryTerms) {
+  const labelText = [
+    facet.label,
+    ...(facet.aliases || [])
+  ].filter(Boolean).join(' ');
+  const evidenceText = [
+    facet.evidence,
+    ...(facet.messageQuotes || []).map((quote) => quote.text)
+  ].filter(Boolean).join(' ');
+  const combinedText = [labelText, evidenceText, facet.sourceText].filter(Boolean).join(' ');
+  const labelScore = cosineSimilarity(queryVector, vectorize(labelText));
+  const combinedScore = cosineSimilarity(queryVector, vectorize(combinedText));
+  const label = normalizeText(labelText);
+  const evidence = normalizeText(evidenceText);
+  const labelBoost = queryTerms.filter((term) => label.includes(term)).length * 0.08;
+  const evidenceBoost = queryTerms.filter((term) => evidence.includes(term)).length * 0.015;
+  return Math.min(combinedScore * 0.75 + labelScore * 0.35 + labelBoost + evidenceBoost, 1);
+}
+
+function aggregateByEmployee(scoredFacets, threshold) {
+  const byEmployee = new Map();
+  for (const item of scoredFacets) {
+    if (item.score < threshold) continue;
+    const key = item.facet.employeeName;
+    if (!byEmployee.has(key)) {
+      byEmployee.set(key, {
+        employeeName: key,
+        slackIds: item.facet.slackIds || [],
+        score: item.score,
+        reasons: [],
+        messageQuotes: []
+      });
+    }
+
+    const result = byEmployee.get(key);
+    result.score = Math.max(result.score, item.score);
+    result.reasons.push({
+      category: item.facet.category,
+      label: item.facet.label,
+      score: Number(item.score.toFixed(4)),
+      evidence: item.facet.evidence
+    });
+    result.messageQuotes.push(...(item.facet.messageQuotes || []));
+  }
+
+  return [...byEmployee.values()]
+    .map((result) => ({
+      ...result,
+      reasons: result.reasons
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 3),
+      messageQuotes: dedupeQuotes(result.messageQuotes).slice(0, 3)
+    }))
+    .sort((a, b) => b.score - a.score || a.employeeName.localeCompare(b.employeeName, 'ja'));
+}
+
+function dedupeQuotes(quotes) {
+  const seen = new Set();
+  const unique = [];
+  for (const quote of quotes) {
+    const key = `${quote.channelId}:${quote.messageTs}:${quote.text}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(quote);
+  }
+  return unique;
+}
+
+function searchFacets(facets, query, options = {}) {
+  const uiCategory = normalizeCategory(options.category || UI_CATEGORY_PERSONAL);
+  const threshold = Number(options.threshold ?? DEFAULT_THRESHOLD);
+  const queryText = stripQueryHelpers(query) || normalizeText(query);
+  const queryVector = vectorize(queryText);
+  const queryTerms = tokenize(queryText);
+
+  const scoredFacets = facets
+    .filter((facet) => facet.uiCategory === uiCategory)
+    .map((facet) => ({
+      facet,
+      score: scoreFacet(facet, queryVector, queryTerms)
+    }));
+
+  return aggregateByEmployee(scoredFacets, threshold);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index++) {
+    const item = argv[index];
+    if (!item.startsWith('--')) continue;
+    args[item.slice(2)] = argv[index + 1] && !argv[index + 1].startsWith('--') ? argv[++index] : true;
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const query = args.query || args.q;
+  if (!query) {
+    console.error('Usage: node scripts/people-finder-rag-search.js --category work --query "AWS運用に詳しい人"');
+    process.exit(1);
+  }
+
+  try {
+    const facets = loadFacets(args.file || DEFAULT_FACETS_FILE);
+    const results = searchFacets(facets, query, {
+      category: args.category,
+      threshold: args.threshold
+    });
+    console.log(JSON.stringify({ query, category: normalizeCategory(args.category || UI_CATEGORY_PERSONAL), results }, null, 2));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  DEFAULT_THRESHOLD,
+  loadFacets,
+  normalizeCategory,
+  normalizeText,
+  searchFacets,
+  stripQueryHelpers,
+  tokenize
+};

--- a/scripts/sync-slack.js
+++ b/scripts/sync-slack.js
@@ -1,9 +1,11 @@
 const fs = require('fs');
 const path = require('path');
 require('dotenv').config();
+const { mergeSlackMessages, readJsonl, writeJsonl } = require('./build-search-facets');
 
 const DATA_FILE = path.join(__dirname, '../data/employees.json');
 const BACKUP_FILE = path.join(__dirname, '../data/employees.backup.json');
+const SLACK_MESSAGES_FILE = path.join(__dirname, '../data/slack-messages.jsonl');
 
 // Configuration - Primary Workspace
 const SLACK_TOKEN = process.env.SLACK_BOT_TOKEN || process.env.SLACK_APP_TOKEN;
@@ -40,12 +42,6 @@ async function main() {
     console.log(`Backed up data to ${BACKUP_FILE}`);
 
     const employees = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
-    const targetEmployees = employees.filter(e => e.isActive !== false && (e.slack_id || e.slack_id_2));
-
-    if (targetEmployees.length === 0) {
-        console.log('No active employees with Slack ID found.');
-        return;
-    }
 
     console.log(`Starting sync... Full Mode: ${IS_FULL_SYNC}`);
     console.log(`Target Channels: ${CHANNEL_IDS.join(', ')}`);
@@ -60,7 +56,7 @@ async function main() {
         try {
             const channelMessages = await fetchSlackMessages(cid, IS_FULL_SYNC, SLACK_TOKEN);
             console.log(`  Fetched ${channelMessages.length} messages from ${cid}`);
-            allMessages = allMessages.concat(channelMessages);
+            allMessages = allMessages.concat(channelMessages.map(m => ({ ...m, channelId: cid, workspace: 'primary' })));
         } catch (e) {
             console.error(`  Failed to fetch from ${cid}: ${e.message}`);
         }
@@ -79,7 +75,7 @@ async function main() {
             try {
                 const channelMessages = await fetchSlackMessages(cid, IS_FULL_SYNC, SLACK_TOKEN_2);
                 console.log(`  Fetched ${channelMessages.length} messages from ${cid}`);
-                allMessages2 = allMessages2.concat(channelMessages);
+                allMessages2 = allMessages2.concat(channelMessages.map(m => ({ ...m, channelId: cid, workspace: 'secondary' })));
             } catch (e) {
                 console.error(`  Failed to fetch from ${cid}: ${e.message}`);
             }
@@ -89,6 +85,22 @@ async function main() {
         console.log('Secondary workspace not configured. Skipping.');
     }
     console.log(`Total messages fetched: ${allMessages.length + allMessages2.length}`);
+
+    const existingSlackMessages = readJsonl(SLACK_MESSAGES_FILE);
+    const mergedSlackMessages = mergeSlackMessages(existingSlackMessages, [...allMessages, ...allMessages2]);
+    writeJsonl(SLACK_MESSAGES_FILE, mergedSlackMessages);
+    console.log(`Saved ${mergedSlackMessages.length} normalized Slack messages to ${SLACK_MESSAGES_FILE}.`);
+
+    const discoveredCount = await registerNewPrimaryWorkspaceUsers(employees, allMessages);
+    if (discoveredCount > 0) {
+        console.log(`Registered ${discoveredCount} newly discovered primary Slack users.`);
+    }
+
+    const targetEmployees = employees.filter(e => e.isActive !== false && (e.slack_id || e.slack_id_2));
+    if (targetEmployees.length === 0) {
+        console.log('No active employees with Slack ID found.');
+        return;
+    }
 
     let updatedCount = 0;
 
@@ -154,14 +166,78 @@ async function main() {
         }
     }
 
-    if (updatedCount > 0) {
+    if (updatedCount > 0 || discoveredCount > 0) {
         fs.writeFileSync(DATA_FILE, JSON.stringify(employees, null, 2));
-        console.log(`Saved ${updatedCount} profiles to ${DATA_FILE}.`);
+        console.log(`Saved ${updatedCount} profile updates and ${discoveredCount} new employees to ${DATA_FILE}.`);
 
         // Regenerate TEAM.md with the new data format
         generateTeamDoc(employees);
     } else {
         console.log('No updates performed.');
+    }
+}
+
+async function registerNewPrimaryWorkspaceUsers(employees, messages) {
+    const knownSlackIds = new Set(employees.flatMap(e => [e.slack_id, e.slack_id_2]).filter(Boolean));
+    const candidateIds = [...new Set(messages
+        .filter(m => m.workspace === 'primary' && m.user && !knownSlackIds.has(m.user) && !m.subtype)
+        .map(m => m.user))];
+    let createdCount = 0;
+
+    for (const userId of candidateIds) {
+        const user = await fetchSlackUserInfo(userId, SLACK_TOKEN);
+        if (!isEligibleSlackUser(user)) continue;
+
+        const name = user.real_name || user.profile?.real_name || user.profile?.display_name;
+        if (!name || employees.some(e => e.name === name)) continue;
+
+        const now = new Date().toISOString();
+        employees.push({
+            name,
+            job: 'Other',
+            slack_id: userId,
+            isActive: true,
+            createdAt: now,
+            updatedAt: now,
+            last_updated: now,
+            overall_summary: '',
+            personality_traits: null,
+            work_styles_and_strengths: null,
+            communication_patterns: null,
+            values_and_motivators: null,
+            current_state: null
+        });
+        knownSlackIds.add(userId);
+        createdCount++;
+    }
+
+    return createdCount;
+}
+
+function isEligibleSlackUser(user) {
+    return Boolean(user)
+        && !user.deleted
+        && !user.is_bot
+        && !user.is_app_user
+        && !user.is_restricted
+        && !user.is_ultra_restricted;
+}
+
+async function fetchSlackUserInfo(userId, token) {
+    const url = `https://slack.com/api/users.info?user=${encodeURIComponent(userId)}`;
+    try {
+        const response = await fetch(url, {
+            headers: { 'Authorization': `Bearer ${token}` }
+        });
+        const data = await response.json();
+        if (!data.ok) {
+            console.warn(`  Could not fetch Slack user ${userId}: ${data.error}`);
+            return null;
+        }
+        return data.user;
+    } catch (error) {
+        console.warn(`  Could not fetch Slack user ${userId}: ${error.message}`);
+        return null;
     }
 }
 

--- a/scripts/test-people-finder-rag-search.js
+++ b/scripts/test-people-finder-rag-search.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { buildSearchFacets, writeSearchFacets } = require('./build-search-facets');
+const { searchFacets, stripQueryHelpers } = require('./people-finder-rag-search');
+
+const employees = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/employees.json'), 'utf8'));
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'people-finder-'));
+const tempFacetsFile = path.join(tempDir, 'search-facets.jsonld');
+
+const sampleMessages = [
+  {
+    id: 'primary:C_TEST:1',
+    workspace: 'primary',
+    channelId: 'C_TEST',
+    user: 'U0AFQUQ1H9R',
+    text: 'ゲームでは最近では特にガンダムバトルオペレーション2をプレイしています。',
+    messageTs: '1770000000.000000',
+    threadTs: null,
+    parentUserId: null,
+    permalink: null
+  }
+];
+
+assert.strictEqual(stripQueryHelpers('ポケモンが好きな人'), 'ポケモン');
+
+const facets = buildSearchFacets(employees, sampleMessages);
+writeSearchFacets(facets, tempFacetsFile);
+
+const graph = JSON.parse(fs.readFileSync(tempFacetsFile, 'utf8'))['@graph'];
+assert(graph.length > employees.length, 'facets should be generated for employees');
+assert(
+  graph.some((facet) => facet.employeeName === '上原基臣' && facet.messageQuotes.length > 0),
+  'message quotes should be attached to matching facets'
+);
+
+const pokemon = searchFacets(graph, 'ポケモンが好きな人', { category: '興味・人柄', threshold: 0.16 })
+  .map((result) => result.employeeName);
+assert(pokemon.includes('小島遼祐'), '小島遼祐 should match pokemon');
+assert(pokemon.includes('藤井芙美子'), '藤井芙美子 should match pokemon');
+assert(pokemon.includes('榎本詩織'), '榎本詩織 should match pokemon');
+
+const aws = searchFacets(graph, 'AWS運用に詳しい人', { category: '仕事・相談', threshold: 0.16 })
+  .map((result) => result.employeeName);
+assert(aws.includes('真栄城則明'), '真栄城則明 should match AWS operations');
+
+const gundam = searchFacets(graph, 'ガンダムが好きな人', { category: '興味・人柄', threshold: 0.16 });
+const uehara = gundam.find((result) => result.employeeName === '上原基臣');
+assert(uehara, '上原基臣 should match Gundam');
+assert(uehara.messageQuotes.length > 0, 'Gundam result should include a message quote');
+
+console.log('people finder RAG search OK');


### PR DESCRIPTION
## 概要
- `employees.json` と正規化済みSlackメッセージ引用から、Slack社員検索向けのJSON-LD facetを生成する `scripts/build-search-facets.js` を追加しました。
- `仕事・相談` と `興味・人柄` のカテゴリ別に類似検索できる `scripts/people-finder-rag-search.js` を追加しました。閾値を超えた社員は全員返し、理由と、保存済みメッセージがある場合は引用も返します。
- Slack同期時に対象チャンネルのメッセージを `data/slack-messages.jsonl` へ正規化保存し、Primaryワークスペースで新しく見つかった通常ユーザーを安全寄りに最小登録する処理を追加しました。
- 定期Slack同期とIssue更新のworkflowで、既存の社員データ・ナレッジグラフ更新に加えて `data/search-facets.jsonld` を再生成するようにしました。

## テスト証跡
- `npm run build:search-facets`
  - ローカルで908件のfacet生成を確認しました。生成ファイルはレビューを軽くするため、このPRには含めていません。workflowまたはnpm scriptで再生成します。
- `npm run test:people-finder`
- `node --check scripts/sync-slack.js`
- `node --check scripts/build-search-facets.js`
- `node --check scripts/people-finder-rag-search.js`
- `node --check scripts/test-people-finder-rag-search.js`
- `git diff --cached --check`

## ブランチ・PR戦略
- Base: `main`。計画PR #66 をマージした後のmainを起点にしています。
- Working branch: `codex/slack-people-finder-rag-core-20260527`
- Scope: 検索データ生成、Slackメッセージ保存、カテゴリ別類似検索、CLIテストまでの第一弾実装です。
- Size note: generator、検索コア、Slack同期連携、テストを同時に入れているため、通常の300行目安より大きめです。SlackモーダルUIとBolt依存追加は次PRへ分割します。

## 残リスク
- 類似検索は外部embedding providerではなく、ローカルの決定的なvector/cosine実装です。まず検索フローの検証には十分ですが、閾値は実際のSlack利用ログを見ながら調整が必要です。
- `data/slack-messages.jsonl` には同期対象チャンネルのメッセージ本文を保存します。広く展開する前に、対象チャンネル範囲と保存期間のルールを合意する必要があります。
- Primary Slackユーザーの自動登録は、`users.info` が使えて、bot・app・削除済み・ゲストでない場合だけ行います。`users:read` が不足している場合は警告してスキップします。
- SlackモーダルUIはこのPRには含めていません。次PRでこの検索コアに接続します。