### PR TITLE
Slack社員検索用のfacetデータを追加

### DIFF
--- a/data/search-facets.jsonld
+++ b/data/search-facets.jsonld
@@ -1,0 +1,15911 @@
+{
+  "@context": {
+    "saiteki": "https://saiteki.example/schema#",
+    "person": "saiteki:person",
+    "uiCategory": "saiteki:uiCategory",
+    "category": "saiteki:category",
+    "label": "saiteki:label",
+    "aliases": "saiteki:aliases",
+    "evidence": "saiteki:evidence",
+    "messageQuotes": "saiteki:messageQuotes",
+    "sourceField": "saiteki:sourceField"
+  },
+  "generatedAt": "2026-05-27T04:06:18.548Z",
+  "sourceFiles": [
+    "data/employees.json",
+    "data/slack-messages.jsonl"
+  ],
+  "@graph": [
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:1",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AI技術の深い知見と実践的な応用力",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:2",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AI時代における組織・人材戦略への深い洞察",
+      "aliases": [
+        "ai時代における組織",
+        "人材戦略への深い洞察",
+        "ai"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:3",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報共有とナレッジマネジメントの推進と仕組み化",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:4",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実行力と迅速な問題解決能力",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:5",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "丁寧で建設的なコミュニケーションとチームガイダンス",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:6",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ワークライフバランスを考慮した柔軟な働き方の提案と実践",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:7",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自己管理能力と状況適応力",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:8",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "戦略的かつ実用的な技術選定能力",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:9",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "高度な知識管理と情報活用戦略の立案・実行",
+      "aliases": [
+        "高度な知識管理と情報活用戦略の立案",
+        "実行"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:10",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "人間中心のAI活用哲学の提唱と浸透",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:11",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "組織文化変革へのリーダーシップ",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:12",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "本質的な価値創造への深い洞察と提言力",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:13",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "深い議論と対話を促すファシリテーション能力",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:14",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "新しい仕組みの探求と構築を楽しむ姿勢",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:15",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "組織の成長と新しい才能の歓迎",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:strength:16",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "計画的なプロジェクト推進とリスク管理",
+      "aliases": [],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:work_style:17",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "AI活用における「なんとなく必要」といった表面的なアプローチに警鐘を鳴らし、「なぜ」を深く掘り下げることで本質的な課題解決を促す。サブエージェントの運用では、計画書を作成し複数の作業割り振りを明確にすることで、プロジェクトの不確実性を管理…",
+      "aliases": [
+        "ai活用における",
+        "なんとなく必要",
+        "といった表面的なアプローチに警鐘を鳴らし",
+        "なぜ",
+        "を深く掘り下げることで本質的な課題解決を促す",
+        "サブエージェントの運用では",
+        "計画書を作成し複数の作業割り振りを明確にすることで",
+        "プロジェクトの不確実性を管理"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:work_topic:18",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AIエージェントの活用と役割分担に関するベストプラクティス",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:work_topic:19",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AI（Letter of T, カスタムチューニング）によるS級人材モデル構築と継続的な運用（ペアデータ、毎週更新）",
+      "aliases": [
+        "ai",
+        "letter",
+        "of",
+        "カスタムチューニング",
+        "によるs級人材モデル構築と継続的な運用",
+        "ペアデータ",
+        "毎週更新"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:work_topic:20",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "Saiteki AI Standardの策定と公開、およびAI活用の本質的な哲学",
+      "aliases": [
+        "saiteki",
+        "ai",
+        "standardの策定と公開",
+        "およびai活用の本質的な哲学",
+        "standard"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:work_topic:21",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AI駆動開発と、それに伴うエンジニアの役割の変化",
+      "aliases": [
+        "ai駆動開発と",
+        "それに伴うエンジニアの役割の変化",
+        "ai"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:work_topic:22",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AIと法務に関する知見の習得",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:work_topic:23",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AI活用ドキュメントの運用とチームの知識共有促進",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:work_topic:24",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "ナレッジベースのカテゴリ設計とRAGを活用した具体的な情報検索の仕組み",
+      "aliases": [
+        "rag"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:work_topic:25",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "Neo4jなどのグラフデータベースを活用した検索ソリューションの検討",
+      "aliases": [
+        "neo4j"
+      ],
+      "evidence": "AI技術への深い知見と、その本質的な価値を追求する戦略的思考で、組織の課題解決と文化変革をリードする。特にゼロからシステムを構築し、探求するプロセスを楽しみ、新しい才能の歓迎を通じて組織のエンゲージメント向上にも貢献する。人間中心のAI活用を提唱し、本質的な価値創造とチーム内の深い議論を促進し、不確実性の高いプロジェクトも計画的に推進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:26",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AIエージェントの活用と役割分担に関するベストプラクティス",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:27",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AI（Letter of T, カスタムチューニング）によるS級人材モデル構築と継続的な運用（ペアデータ、毎週更新）",
+      "aliases": [
+        "ai",
+        "letter",
+        "of",
+        "カスタムチューニング",
+        "によるs級人材モデル構築と継続的な運用",
+        "ペアデータ",
+        "毎週更新"
+      ],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:28",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Saiteki AI Standardの策定と公開、およびAI活用の本質的な哲学",
+      "aliases": [
+        "saiteki",
+        "ai",
+        "standardの策定と公開",
+        "およびai活用の本質的な哲学",
+        "standard"
+      ],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:29",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AI駆動開発と、それに伴うエンジニアの役割の変化",
+      "aliases": [
+        "ai駆動開発と",
+        "それに伴うエンジニアの役割の変化",
+        "ai"
+      ],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:30",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AIと法務に関する知見の習得",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:31",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AI活用ドキュメントの運用とチームの知識共有促進",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:32",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ナレッジベースのカテゴリ設計とRAGを活用した具体的な情報検索の仕組み",
+      "aliases": [
+        "rag"
+      ],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:33",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Neo4jなどのグラフデータベースを活用した検索ソリューションの検討",
+      "aliases": [
+        "neo4j"
+      ],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:34",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "新入社員の歓迎と社内交流",
+      "aliases": [],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:35",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ゼロからのシステム構築と探求",
+      "aliases": [],
+      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:36",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "技術革新と探求 (特にAIと知識グラフ、ベクトル検索、AI駆動開発)",
+      "aliases": [
+        "技術革新と探求",
+        "特にaiと知識グラフ",
+        "ベクトル検索",
+        "ai駆動開発",
+        "ai"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:37",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "組織・チームへの貢献 (ナレッジ共有、業務効率化、コミュニケーション改善)",
+      "aliases": [
+        "組織",
+        "チームへの貢献",
+        "ナレッジ共有",
+        "業務効率化",
+        "コミュニケーション改善"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:38",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "自律的な行動と役割の拡張",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:39",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "AI時代における組織の適応と成長",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:40",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "未来を見据えた継続的な学習と洞察 (特にAIと法)",
+      "aliases": [
+        "未来を見据えた継続的な学習と洞察",
+        "特にaiと法",
+        "ai"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:41",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "実践を通じた技術検証と実装",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:42",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "オープンな情報共有と透明性",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:43",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "ワークライフバランスの重視と、それによる持続可能な貢献",
+      "aliases": [
+        "ワークライフバランスの重視と",
+        "それによる持続可能な貢献"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:44",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "体系的な知識共有と活用",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:45",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "人間中心のAI活用と価値創造",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:46",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "本質的な問い（Why）の追求",
+      "aliases": [
+        "本質的な問い",
+        "why",
+        "の追求"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:47",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "チーム内の深い対話と協調",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:48",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "組織文化の変革と進化",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:49",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "新しいシステムや仕組みの開拓",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:50",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "組織への新しい才能の導入と育成",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:51",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "知識共有とベストプラクティス探索",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:52",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "計画的なプロジェクト推進",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:53",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "AI技術が組織の文化や働き方を良い方向に変革すること",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:54",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身のアイデアや知見を活かして具体的な仕組みを構築し、その効果を実感すること",
+      "aliases": [
+        "自身のアイデアや知見を活かして具体的な仕組みを構築し",
+        "その効果を実感すること"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:55",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームのナレッジ蓄積や情報活用の効率化に貢献すること",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:56",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "メンバーが自律的に課題を見つけ解決する組織風土を醸成すること",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:57",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "技術的な問題を迅速に解決し、システムを安定稼働させること",
+      "aliases": [
+        "技術的な問題を迅速に解決し",
+        "システムを安定稼働させること"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:58",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新たな技術や社会の変化に関する知識を深く学び、それを周囲と共有すること",
+      "aliases": [
+        "新たな技術や社会の変化に関する知識を深く学び",
+        "それを周囲と共有すること"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:59",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "知識共有の仕組みを構築し、組織全体の知の活用を促進すること",
+      "aliases": [
+        "知識共有の仕組みを構築し",
+        "組織全体の知の活用を促進すること"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:60",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームや組織の生産性が向上すること",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:61",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "AIが単なる効率化ツールでなく、より本質的な思考と深い議論を促進するきっかけとなること",
+      "aliases": [
+        "aiが単なる効率化ツールでなく",
+        "より本質的な思考と深い議論を促進するきっかけとなること",
+        "ai"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:62",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "組織全体がAI時代に合わせた思考様式と働き方に変革していく過程",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:63",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の策定したガイドラインが組織全体に浸透し、具体的な行動変容に繋がること",
+      "aliases": [
+        "自身の策定したガイドラインが組織全体に浸透し",
+        "具体的な行動変容に繋がること"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:64",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "ワークライフバランスを保ちつつ、自身の能力を最大限に発揮し、組織に貢献すること",
+      "aliases": [
+        "ワークライフバランスを保ちつつ",
+        "自身の能力を最大限に発揮し",
+        "組織に貢献すること"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:65",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "ゼロからアイデアを形にしていくプロセス",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:66",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい技術を活用した人材育成の可能性を探求すること",
+      "aliases": [],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:67",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の知識や経験を共有し、他者の学びや組織の成長を促すこと",
+      "aliases": [
+        "自身の知識や経験を共有し",
+        "他者の学びや組織の成長を促すこと"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:68",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:杉本光一",
+      "employeeName": "杉本光一",
+      "slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "AIエージェントによる業務の効率化と品質向上",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "最新AI技術への探求心に加えて、その本質的な意味と人間社会・組織への影響を深く考察し、人間中心の価値創造と組織文化の変革に最大の喜びを見出す。特に、ゼロから新しい仕組みやシステムを開拓し、形にしていくプロセスに強いモチベーションを感じる。全社的なAI活用ガイドライン『Saiteki AI Standard』の策定を通じて、AI時代における「なぜ」を追求する…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:69",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "インフラ設計・構築スキル",
+      "aliases": [
+        "インフラ設計",
+        "構築スキル"
+      ],
+      "evidence": "AWS基盤のインフラ設計・構築に高い専門性を持ちつつ、未経験技術への学習意欲が極めて高い。責任感が強く、チームワークと自己成長を重視して業務に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:70",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "学習意欲",
+      "aliases": [],
+      "evidence": "AWS基盤のインフラ設計・構築に高い専門性を持ちつつ、未経験技術への学習意欲が極めて高い。責任感が強く、チームワークと自己成長を重視して業務に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:71",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コミュニケーション能力",
+      "aliases": [],
+      "evidence": "AWS基盤のインフラ設計・構築に高い専門性を持ちつつ、未経験技術への学習意欲が極めて高い。責任感が強く、チームワークと自己成長を重視して業務に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:72",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "責任感",
+      "aliases": [],
+      "evidence": "AWS基盤のインフラ設計・構築に高い専門性を持ちつつ、未経験技術への学習意欲が極めて高い。責任感が強く、チームワークと自己成長を重視して業務に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:work_style:73",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "未経験の技術や困難に直面しても、それをスキルアップの好機と捉え、前向きな姿勢で学びと経験を積み重ね、解決策を模索する。",
+      "aliases": [
+        "未経験の技術や困難に直面しても",
+        "それをスキルアップの好機と捉え",
+        "前向きな姿勢で学びと経験を積み重ね",
+        "解決策を模索する"
+      ],
+      "evidence": "AWS基盤のインフラ設計・構築に高い専門性を持ちつつ、未経験技術への学習意欲が極めて高い。責任感が強く、チームワークと自己成長を重視して業務に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:work_topic:74",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "Saitekiメンバーの入社経緯",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "AWS基盤のインフラ設計・構築に高い専門性を持ちつつ、未経験技術への学習意欲が極めて高い。責任感が強く、チームワークと自己成長を重視して業務に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:work_topic:75",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "BIツールの知識習得",
+      "aliases": [
+        "bi"
+      ],
+      "evidence": "AWS基盤のインフラ設計・構築に高い専門性を持ちつつ、未経験技術への学習意欲が極めて高い。責任感が強く、チームワークと自己成長を重視して業務に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:76",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Saitekiメンバーの入社経緯",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "年末年始を通してSaitekiメンバーとの出会いに深く感謝し、2026年を「飛躍の年」と意気込んでいる。12月上旬には業務負荷が高い様子が伺えたが、それを乗り越え、現在は非常に前向きな精神状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:77",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "京都旅行",
+      "aliases": [],
+      "evidence": "年末年始を通してSaitekiメンバーとの出会いに深く感謝し、2026年を「飛躍の年」と意気込んでいる。12月上旬には業務負荷が高い様子が伺えたが、それを乗り越え、現在は非常に前向きな精神状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:78",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "2025年の振り返りと2026年への期待",
+      "aliases": [
+        "2025",
+        "2026"
+      ],
+      "evidence": "年末年始を通してSaitekiメンバーとの出会いに深く感謝し、2026年を「飛躍の年」と意気込んでいる。12月上旬には業務負荷が高い様子が伺えたが、それを乗り越え、現在は非常に前向きな精神状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:79",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "BIツールの知識習得",
+      "aliases": [
+        "bi"
+      ],
+      "evidence": "年末年始を通してSaitekiメンバーとの出会いに深く感謝し、2026年を「飛躍の年」と意気込んでいる。12月上旬には業務負荷が高い様子が伺えたが、それを乗り越え、現在は非常に前向きな精神状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:80",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "家族",
+      "aliases": [],
+      "evidence": "家族との時間を大切にし、仕事では新しい技術の習得と自己成長を追求。組織への貢献意欲とSaitekiの一員であることへの誇り、メンバーとの交流を非常に重視している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:81",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "成長",
+      "aliases": [],
+      "evidence": "家族との時間を大切にし、仕事では新しい技術の習得と自己成長を追求。組織への貢献意欲とSaitekiの一員であることへの誇り、メンバーとの交流を非常に重視している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:82",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "貢献",
+      "aliases": [],
+      "evidence": "家族との時間を大切にし、仕事では新しい技術の習得と自己成長を追求。組織への貢献意欲とSaitekiの一員であることへの誇り、メンバーとの交流を非常に重視している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:83",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "責任",
+      "aliases": [],
+      "evidence": "家族との時間を大切にし、仕事では新しい技術の習得と自己成長を追求。組織への貢献意欲とSaitekiの一員であることへの誇り、メンバーとの交流を非常に重視している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:84",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい技術の習得",
+      "aliases": [],
+      "evidence": "家族との時間を大切にし、仕事では新しい技術の習得と自己成長を追求。組織への貢献意欲とSaitekiの一員であることへの誇り、メンバーとの交流を非常に重視している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:85",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームへの貢献",
+      "aliases": [],
+      "evidence": "家族との時間を大切にし、仕事では新しい技術の習得と自己成長を追求。組織への貢献意欲とSaitekiの一員であることへの誇り、メンバーとの交流を非常に重視している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:86",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自己成長",
+      "aliases": [],
+      "evidence": "家族との時間を大切にし、仕事では新しい技術の習得と自己成長を追求。組織への貢献意欲とSaitekiの一員であることへの誇り、メンバーとの交流を非常に重視している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:87",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:青木淳一郎",
+      "employeeName": "青木淳一郎",
+      "slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "人との交流",
+      "aliases": [],
+      "evidence": "家族との時間を大切にし、仕事では新しい技術の習得と自己成長を追求。組織への貢献意欲とSaitekiの一員であることへの誇り、メンバーとの交流を非常に重視している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:88",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "テスト・品質管理経験",
+      "aliases": [
+        "テスト",
+        "品質管理経験"
+      ],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:89",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コミュニケーション能力",
+      "aliases": [],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:90",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報収集力",
+      "aliases": [],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:91",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報提供力",
+      "aliases": [],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:92",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "状況説明能力",
+      "aliases": [],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:93",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "協調性",
+      "aliases": [],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:94",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "詳細観察力",
+      "aliases": [],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:95",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "計画性",
+      "aliases": [],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:96",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実行力",
+      "aliases": [],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:97",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "適応力",
+      "aliases": [],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:work_style:98",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "環境移行時において、懸念事項を事前に洗い出し、荷解き、ネット開通、在宅勤務環境の確認といったタスクを計画的にこなすことで問題を解決し、安心を確保する論理的かつ実践的なアプローチをとる。",
+      "aliases": [
+        "環境移行時において",
+        "懸念事項を事前に洗い出し",
+        "荷解き",
+        "ネット開通",
+        "在宅勤務環境の確認といったタスクを計画的にこなすことで問題を解決し",
+        "安心を確保する論理的かつ実践的なアプローチをとる"
+      ],
+      "evidence": "長年の経験に裏打ちされた細部への注意と、高いコミュニケーション能力が強み。新しい情報や知識の吸収にも積極的で、協調性を持ちながら業務に取り組む。状況把握と情報共有に長け、自身の経験を活かした具体的な提案も期待できる。計画性、実行力、そして適応力に優れる。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:99",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "新しい一人暮らしの生活",
+      "aliases": [],
+      "evidence": "東京での一人暮らしへの移行を完了し、引っ越しに伴う主要なタスク（荷解き、ネット開通、在宅勤務環境の確認）を計画通りに解消したことで、精神的・肉体的な負荷が軽減されている。新しい生活への期待と、残りの連休を楽しむ意欲に満ちた、非常にポジティブで安定した状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:100",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "引っ越し後の環境整備（荷解き、ネット開通）",
+      "aliases": [
+        "引っ越し後の環境整備",
+        "荷解き",
+        "ネット開通"
+      ],
+      "evidence": "東京での一人暮らしへの移行を完了し、引っ越しに伴う主要なタスク（荷解き、ネット開通、在宅勤務環境の確認）を計画通りに解消したことで、精神的・肉体的な負荷が軽減されている。新しい生活への期待と、残りの連休を楽しむ意欲に満ちた、非常にポジティブで安定した状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:101",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "在宅勤務環境の確認",
+      "aliases": [],
+      "evidence": "東京での一人暮らしへの移行を完了し、引っ越しに伴う主要なタスク（荷解き、ネット開通、在宅勤務環境の確認）を計画通りに解消したことで、精神的・肉体的な負荷が軽減されている。新しい生活への期待と、残りの連休を楽しむ意欲に満ちた、非常にポジティブで安定した状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:102",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "連休の過ごし方",
+      "aliases": [],
+      "evidence": "東京での一人暮らしへの移行を完了し、引っ越しに伴う主要なタスク（荷解き、ネット開通、在宅勤務環境の確認）を計画通りに解消したことで、精神的・肉体的な負荷が軽減されている。新しい生活への期待と、残りの連休を楽しむ意欲に満ちた、非常にポジティブで安定した状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:103",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ネット回線速度の改善",
+      "aliases": [],
+      "evidence": "東京での一人暮らしへの移行を完了し、引っ越しに伴う主要なタスク（荷解き、ネット開通、在宅勤務環境の確認）を計画通りに解消したことで、精神的・肉体的な負荷が軽減されている。新しい生活への期待と、残りの連休を楽しむ意欲に満ちた、非常にポジティブで安定した状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:104",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "成長",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:105",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "協調",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:106",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "楽しさ",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:107",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "探求",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:108",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "繋がり",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:109",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "経験の共有",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:110",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "新しい挑戦",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:111",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "安定",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:112",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "自律性",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:113",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい知識やスキルの習得",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:114",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームへの貢献と協業",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:115",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "楽しい経験や趣味の追求",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:116",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "共通の興味を持つ人々との交流",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:117",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "興味を持ったことの詳細な情報共有",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:118",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自己開示を通じた人間関係の深化",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:119",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい環境での生活の確立",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:120",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小林翔",
+      "employeeName": "小林翔",
+      "slackIds": [
+        "U09S602LZS7"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "計画の実行と達成",
+      "aliases": [],
+      "evidence": "成長、繋がり、楽しさ、探求、そして経験を重視する。新しい挑戦や安定した環境の確立、自律性を重んじ、自身の情熱を共有することがモチベーションの源泉となる。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:strength:121",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "データ分析",
+      "aliases": [],
+      "evidence": "データに基づいた分析力と高い学習意欲を持ち、自ら専門性を深めようと努力します。チームでのコミュニケーションを重視し、協調的に仕事を進めるタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:strength:122",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "学習意欲",
+      "aliases": [],
+      "evidence": "データに基づいた分析力と高い学習意欲を持ち、自ら専門性を深めようと努力します。チームでのコミュニケーションを重視し、協調的に仕事を進めるタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:strength:123",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コミュニケーション",
+      "aliases": [],
+      "evidence": "データに基づいた分析力と高い学習意欲を持ち、自ら専門性を深めようと努力します。チームでのコミュニケーションを重視し、協調的に仕事を進めるタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_style:124",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "データ分析スキルを活かし、論理的な思考で現状を把握し問題解決に取り組むアプローチを取ります。",
+      "aliases": [
+        "データ分析スキルを活かし",
+        "論理的な思考で現状を把握し問題解決に取り組むアプローチを取ります"
+      ],
+      "evidence": "データに基づいた分析力と高い学習意欲を持ち、自ら専門性を深めようと努力します。チームでのコミュニケーションを重視し、協調的に仕事を進めるタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_topic:125",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "データ分析",
+      "aliases": [],
+      "evidence": "データに基づいた分析力と高い学習意欲を持ち、自ら専門性を深めようと努力します。チームでのコミュニケーションを重視し、協調的に仕事を進めるタイプです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_topic:126",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "データベース構築",
+      "aliases": [],
+      "evidence": "データに基づいた分析力と高い学習意欲を持ち、自ら専門性を深めようと努力します。チームでのコミュニケーションを重視し、協調的に仕事を進めるタイプです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_topic:127",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "Slackを通じたコミュニケーション",
+      "aliases": [
+        "slack"
+      ],
+      "evidence": "データに基づいた分析力と高い学習意欲を持ち、自ら専門性を深めようと努力します。チームでのコミュニケーションを重視し、協調的に仕事を進めるタイプです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:interest:128",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "データ分析",
+      "aliases": [],
+      "evidence": "1月からの入社を控えており、新しい環境に対する高い期待感と意欲に満ち溢れています。自身のスキルを活かしつつ、さらなる専門性向上とチームへの貢献を目指しています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:interest:129",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "データベース構築",
+      "aliases": [],
+      "evidence": "1月からの入社を控えており、新しい環境に対する高い期待感と意欲に満ち溢れています。自身のスキルを活かしつつ、さらなる専門性向上とチームへの貢献を目指しています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:interest:130",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "資格取得",
+      "aliases": [],
+      "evidence": "1月からの入社を控えており、新しい環境に対する高い期待感と意欲に満ち溢れています。自身のスキルを活かしつつ、さらなる専門性向上とチームへの貢献を目指しています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:interest:131",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Slackを通じたコミュニケーション",
+      "aliases": [
+        "slack"
+      ],
+      "evidence": "1月からの入社を控えており、新しい環境に対する高い期待感と意欲に満ち溢れています。自身のスキルを活かしつつ、さらなる専門性向上とチームへの貢献を目指しています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:132",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "成長",
+      "aliases": [],
+      "evidence": "自身の成長と専門性向上を重視し、新しい知識やスキルを習得することに喜びを感じる人物です。チームワークを大切にし、周囲との良好な関係を築きながら貢献することにモチベーションを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:133",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "貢献",
+      "aliases": [],
+      "evidence": "自身の成長と専門性向上を重視し、新しい知識やスキルを習得することに喜びを感じる人物です。チームワークを大切にし、周囲との良好な関係を築きながら貢献することにモチベーションを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:134",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "協調性",
+      "aliases": [],
+      "evidence": "自身の成長と専門性向上を重視し、新しい知識やスキルを習得することに喜びを感じる人物です。チームワークを大切にし、周囲との良好な関係を築きながら貢献することにモチベーションを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:135",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "専門性",
+      "aliases": [],
+      "evidence": "自身の成長と専門性向上を重視し、新しい知識やスキルを習得することに喜びを感じる人物です。チームワークを大切にし、周囲との良好な関係を築きながら貢献することにモチベーションを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:136",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい知識やスキルの習得",
+      "aliases": [],
+      "evidence": "自身の成長と専門性向上を重視し、新しい知識やスキルを習得することに喜びを感じる人物です。チームワークを大切にし、周囲との良好な関係を築きながら貢献することにモチベーションを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:137",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "専門性の向上",
+      "aliases": [],
+      "evidence": "自身の成長と専門性向上を重視し、新しい知識やスキルを習得することに喜びを感じる人物です。チームワークを大切にし、周囲との良好な関係を築きながら貢献することにモチベーションを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:138",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームへの貢献",
+      "aliases": [],
+      "evidence": "自身の成長と専門性向上を重視し、新しい知識やスキルを習得することに喜びを感じる人物です。チームワークを大切にし、周囲との良好な関係を築きながら貢献することにモチベーションを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:139",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:櫻井志保",
+      "employeeName": "櫻井志保",
+      "slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自己管理を通じたパフォーマンス維持",
+      "aliases": [],
+      "evidence": "自身の成長と専門性向上を重視し、新しい知識やスキルを習得することに喜びを感じる人物です。チームワークを大切にし、周囲との良好な関係を築きながら貢献することにモチベーションを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:140",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "開発プロセス全体（要件定義〜実装）への深い知見と標準化への貢献",
+      "aliases": [
+        "開発プロセス全体",
+        "要件定義〜実装",
+        "への深い知見と標準化への貢献"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:141",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "アジャイル開発の本質的な理解と実践（特にリスクコントロールと不確実性分解）",
+      "aliases": [
+        "アジャイル開発の本質的な理解と実践",
+        "特にリスクコントロールと不確実性分解"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:142",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AI駆動開発の実践と知識共有（特に標準化・ガイドライン作成）",
+      "aliases": [
+        "ai駆動開発の実践と知識共有",
+        "特に標準化",
+        "ガイドライン作成",
+        "ai"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:143",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "顧客視点での課題解決と安心感の提供のための徹底した準備と自信ある回答",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:144",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "チーム立ち上げ・品質改善（レビューを通じた貢献）",
+      "aliases": [
+        "チーム立ち上げ",
+        "品質改善",
+        "レビューを通じた貢献"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:145",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ビジネスモデルへの深い洞察と分析力",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:146",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "システム開発最上流工程への深い理解と重視",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:147",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "仮説検証に基づくプレゼン・資料設計と改善",
+      "aliases": [
+        "仮説検証に基づくプレゼン",
+        "資料設計と改善"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:148",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自身の時間管理と周囲への明確な伝達",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:149",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自身の業務状況を正直かつ建設的に報告する能力",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:150",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "会議の効率化を提案する配慮",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:151",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "困難な状況における諦めない姿勢と解決策模索能力",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:152",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "リーダーシップのビジョンへの深い共感と戦略的アラインメント",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:153",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "Saitekiの独自の顧客貢献アプローチへの理解と推進",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:154",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "顧客との「泥臭い対話」を重視する姿勢",
+      "aliases": [
+        "顧客との",
+        "泥臭い対話",
+        "を重視する姿勢"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:155",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "顧客の意思決定の文脈を理解し、提案を調整する柔軟性と機動力",
+      "aliases": [
+        "顧客の意思決定の文脈を理解し",
+        "提案を調整する柔軟性と機動力"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:156",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "SIerやコンサルティングファームとの差別化ポイントを明確に言語化する戦略的思考",
+      "aliases": [
+        "sier"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:157",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "リスク制御と早期開発を両立する実践的な提案力",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:158",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "顧客のシステム部門を担うというSaitekiのビジョン実現への強いコミットメント",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:159",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実績を通じて会社のポジションを確立しようとする能動性",
+      "aliases": [],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:160",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "Saitekiのビジョン達成への強いコミットメント",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:161",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "人材を見極め、チームへの適応を促す視点",
+      "aliases": [
+        "人材を見極め",
+        "チームへの適応を促す視点"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:work_style:162",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "PoCにおいては、最初に全てを決め切らず、仮説を立て、クライアントとの密なすり合わせを通じて要件や計画を段階的にアップデートしていくアジャイルなアプローチを重視する。アジャイルの真髄を「不確実性を分解し、リスクをコントロール可能な形に変え…",
+      "aliases": [
+        "pocにおいては",
+        "最初に全てを決め切らず",
+        "仮説を立て",
+        "クライアントとの密なすり合わせを通じて要件や計画を段階的にアップデートしていくアジャイルなアプローチを重視する",
+        "アジャイルの真髄を",
+        "不確実性を分解し",
+        "リスクをコントロール可能な形に変え",
+        "poc"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:work_topic:163",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "Saitekiのビジョンと業界課題の解決",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "AI技術を核とした開発プロセスの深い知見を持ち、アジャイルの本質であるリスクコントロールを重視する。Saitekiの独自の顧客貢献ビジョンに深く共感し、特に「顧客の意思決定の文脈に乗せる」機動力と柔軟性を重視。困難な状況でも諦めずに解決策を模索し、会社のユニークなポジション確立を推進する強い推進力と責任感を持って業務に取り組む。組織のビジョン達成への強いコ…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:interest:164",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Saitekiのビジョンと業界課題の解決",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "同僚が執筆したnoteの内容に深く感動し、Saitekiのビジョン実現と業界課題解決への自身のコミットメントを再確認している。新しいメンバーの参加を心から歓迎し、彼が組織に合うことを見抜いていたことを伝え、今後のプロジェクトでの協業を楽しみにする、非常にポジティブな状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:interest:165",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "新しいメンバーの歓迎と今後の協業",
+      "aliases": [],
+      "evidence": "同僚が執筆したnoteの内容に深く感動し、Saitekiのビジョン実現と業界課題解決への自身のコミットメントを再確認している。新しいメンバーの参加を心から歓迎し、彼が組織に合うことを見抜いていたことを伝え、今後のプロジェクトでの協業を楽しみにする、非常にポジティブな状態にある。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:166",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "チームワーク",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:167",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "継続的な学習と技術革新（特にAIの探求と標準化、アジャイルの本質的な実践）",
+      "aliases": [
+        "継続的な学習と技術革新",
+        "特にaiの探求と標準化",
+        "アジャイルの本質的な実践",
+        "ai"
+      ],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:168",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "顧客満足と貢献（特に顧客への安心感提供と信頼構築）",
+      "aliases": [
+        "顧客満足と貢献",
+        "特に顧客への安心感提供と信頼構築"
+      ],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:169",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "誠実さ",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:170",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "知識共有と後進育成",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:171",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "リスクコントロールと不確実性の管理",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:172",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "家族",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:173",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "SaitekiのMVVへの共感",
+      "aliases": [
+        "saiteki",
+        "mvv"
+      ],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:174",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "多様な専門性を持つメンバー間のシナジー",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:175",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "組織文化の形成と改善",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:176",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "同僚への配慮とサポート",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:177",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "責任ある情報開示",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:178",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "チームの効率性",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:179",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "Saitekiのユニークなポジションへの貢献",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:180",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "困難克服への挑戦",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:181",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "顧客との泥臭い対話",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:182",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "顧客の意思決定の文脈尊重",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:183",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "市場での差別化と独自のポジション確立",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:184",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "プロトタイプとリスク制御による実践的なアジャイル",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:185",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "Saitekiのビジョン実現と業界課題の解決への貢献",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:186",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームメンバーからの感謝と成長の実感",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:187",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の知識共有がチームや後進の成長に貢献できたという実感",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:188",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい技術（特にAI）の習得と実践、そしてその標準化への挑戦",
+      "aliases": [
+        "新しい技術",
+        "特にai",
+        "の習得と実践",
+        "そしてその標準化への挑戦",
+        "ai"
+      ],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:189",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の専門性が組織の共通認識や文化として定着し、会社全体の成長に貢献すること",
+      "aliases": [
+        "自身の専門性が組織の共通認識や文化として定着し",
+        "会社全体の成長に貢献すること"
+      ],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:190",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "顧客からの肯定的なフィードバックとプロジェクトの成功、顧客から信頼を得ること",
+      "aliases": [
+        "顧客からの肯定的なフィードバックとプロジェクトの成功",
+        "顧客から信頼を得ること"
+      ],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:191",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "Saitekiのビジョン実現と業界課題の解決に貢献できる実感",
+      "aliases": [
+        "saiteki"
+      ],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:192",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:田浦裕樹",
+      "employeeName": "田浦裕樹",
+      "slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しいメンバーと共に働くことへの期待と喜び",
+      "aliases": [],
+      "evidence": "Saitekiのビジョンと顧客への貢献に強い信頼とコミットメントを持ち、自身の経験と知識を活かして組織全体の成長と顧客の成功に貢献することに大きな価値を見出す。特に、顧客の意思決定の文脈を理解し、Saiteki独自の市場ポジションを確立することに強い意欲とモチベーションを感じる。困難な状況でも諦めずに解決策を模索し、責任感を持って業務を推進することにモチベ…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:193",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "QAエンジニアリングの専門知識と長年の経験",
+      "aliases": [
+        "qa"
+      ],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:194",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AI技術の業務適用能力と実践力",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:195",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "テストプロセスの戦略的改善提案と実行力",
+      "aliases": [],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:196",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "人とAIの協働作業の概念化と推進",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:197",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報共有と進捗報告の明確さ",
+      "aliases": [],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:198",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自律的なタスク管理と品質追求",
+      "aliases": [],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_style:199",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "既存のテストプロセス（汎用テスト観点）を現状維持ではなく、より効果的な「テスト計画フェーズ」へと戦略的にシフトさせようとする。AIを活用した協働作業を具体的に「書き出し」て概念化するなど、新しい技術を実践的に取り入れ、人とAIの最適な役割…",
+      "aliases": [
+        "既存のテストプロセス",
+        "汎用テスト観点",
+        "を現状維持ではなく",
+        "より効果的な",
+        "テスト計画フェーズ",
+        "へと戦略的にシフトさせようとする",
+        "aiを活用した協働作業を具体的に",
+        "書き出し"
+      ],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:200",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "QAにおけるAI協働作業の定義と実践",
+      "aliases": [
+        "qa",
+        "ai"
+      ],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:201",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "人とAIの役割分担と成果物の作成",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:202",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "テスト計画フェーズの最適化",
+      "aliases": [],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:203",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "汎用テスト観点の修正と改善",
+      "aliases": [],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:204",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "Notion等を用いた情報共有とドキュメンテーション",
+      "aliases": [
+        "notion"
+      ],
+      "evidence": "QAエンジニアとしての経験に基づき、AI技術を積極的に業務プロセスに取り入れ、効率的かつ戦略的な改善を推進する。情報共有を重視し、自律的にタスクを遂行しながら常に最適化を追求する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:205",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "QAにおけるAI協働作業の定義と実践",
+      "aliases": [
+        "qa",
+        "ai"
+      ],
+      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:206",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "人とAIの役割分担と成果物の作成",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:207",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "テスト計画フェーズの最適化",
+      "aliases": [],
+      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:208",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "汎用テスト観点の修正と改善",
+      "aliases": [],
+      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:209",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Notion等を用いた情報共有とドキュメンテーション",
+      "aliases": [
+        "notion"
+      ],
+      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:210",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "探求心",
+      "aliases": [],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:211",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "効率性",
+      "aliases": [],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:212",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "品質改善",
+      "aliases": [],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:213",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "貢献",
+      "aliases": [],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:214",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "協調性",
+      "aliases": [],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:215",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "戦略的思考",
+      "aliases": [],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:216",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい技術の導入と実践（特にAI）",
+      "aliases": [
+        "新しい技術の導入と実践",
+        "特にai",
+        "ai"
+      ],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:217",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "業務プロセスの抜本的な改善と最適化",
+      "aliases": [],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:218",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "具体的な成果物の完成と品質向上",
+      "aliases": [],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:219",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "人との協働を通じた課題解決と新しい働き方の創出",
+      "aliases": [],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:220",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:開米 敦則",
+      "employeeName": "開米 敦則",
+      "slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の計画を実行し、目標を達成すること",
+      "aliases": [
+        "自身の計画を実行し",
+        "目標を達成すること"
+      ],
+      "evidence": "新しい技術（AI）の積極的な探求と業務への適用、プロセス全体の効率化と品質向上に強い意欲を持つ。チームへの貢献意識も高く、情報共有や意見交換を通じて成果を最大化しようとする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:221",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "福利厚生プログラムの企画・導入・推進",
+      "aliases": [
+        "福利厚生プログラムの企画",
+        "導入",
+        "推進"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:222",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "社員のウェルビーイング支援",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:223",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "明瞭な情報発信力",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:224",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "他者貢献・協調性",
+      "aliases": [
+        "他者貢献",
+        "協調性"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:225",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "人材獲得・リファラル採用推進",
+      "aliases": [
+        "人材獲得",
+        "リファラル採用推進"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:226",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "計画・実行力",
+      "aliases": [
+        "計画",
+        "実行力"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:227",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "社内コミュニティ活性化",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:228",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "インクルージョン推進",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:229",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "イベント企画・運営",
+      "aliases": [
+        "イベント企画",
+        "運営"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:230",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ファシリテーション能力",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:231",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "継続的改善志向",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:232",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "外部コンテンツプロモーション",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:233",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ビジネス知見共有",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:234",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "学習機会の提供",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:235",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コンテンツキュレーション",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:236",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "企業ブランディング強化",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:237",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "DX推進",
+      "aliases": [
+        "dx"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:238",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AI技術トレンドのキャッチアップ・共有",
+      "aliases": [
+        "ai技術トレンドのキャッチアップ",
+        "共有",
+        "ai"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:239",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "社員の技術力向上支援",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:240",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "技術とビジネスの橋渡し",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:241",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実践的な学習コンテンツの選定・提示",
+      "aliases": [
+        "実践的な学習コンテンツの選定",
+        "提示"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_style:242",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "社員のコンディション向上という課題に対し、外部プログラム導入や具体的なサポートで対応。人材獲得には、明確なインセンティブ制度を設けて社内からの紹介を促す。社内交流の希薄化には、参加ハードルの低いイベントを企画し、インクルーシブな呼びかけで…",
+      "aliases": [
+        "社員のコンディション向上という課題に対し",
+        "外部プログラム導入や具体的なサポートで対応",
+        "人材獲得には",
+        "明確なインセンティブ制度を設けて社内からの紹介を促す",
+        "社内交流の希薄化には",
+        "参加ハードルの低いイベントを企画し",
+        "インクルーシブな呼びかけで"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:243",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "リファラル採用の推進",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:244",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AI駆動開発 (AI-driven development)",
+      "aliases": [
+        "ai駆動開発",
+        "ai-driven",
+        "development",
+        "ai",
+        "driven"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:245",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "Claude Code / Cursor",
+      "aliases": [
+        "claude",
+        "code",
+        "cursor"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:246",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "MCP・AIエージェント活用",
+      "aliases": [
+        "mcp",
+        "aiエージェント活用",
+        "ai"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:247",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "SDD × AI駆動開発フロー",
+      "aliases": [
+        "sdd",
+        "ai駆動開発フロー",
+        "ai"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:248",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AWSアーキテクチャ設計",
+      "aliases": [
+        "aws"
+      ],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:249",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "技術的理想と事業的理想の合意形成",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:250",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "技術的負債と事業成長のバランス",
+      "aliases": [],
+      "evidence": "社員のウェルビーイング向上、会社成長のための人材獲得、社内コミュニティの活性化に加え、外部への情報発信を通じたブランド価値向上と社員の学習機会提供を優先課題の一つとし、プログラム導入・推進、イベント企画、コンテンツ共有に尽力している。明確で構造化された情報発信を通じて、社員の積極的な参加と理解を促す能力に加え、細部にまで配慮したコンテンツ選定・提示を通じて…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:251",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "セルフマネジメントプログラムの導入・推進",
+      "aliases": [
+        "セルフマネジメントプログラムの導入",
+        "推進"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:252",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "社員の心身の健康とウェルビーイング",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:253",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "福利厚生プログラムの効果的な活用促進",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:254",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "長期的なキャリア形成とコンディション維持",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:255",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "リファラル採用の推進",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:256",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "優秀な人材獲得",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:257",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "組織全体のパフォーマンス向上",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:258",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "社内コミュニティ活性化",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:259",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "従業員エンゲージメント向上",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:260",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "インクルージョン",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:261",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "オンライン交流イベントの企画・運営・改善",
+      "aliases": [
+        "オンライン交流イベントの企画",
+        "運営",
+        "改善"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:262",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "外部ビジネス戦略・知見",
+      "aliases": [
+        "外部ビジネス戦略",
+        "知見"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:263",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "アナログトランスフォーメーション (AX)",
+      "aliases": [
+        "アナログトランスフォーメーション",
+        "ax"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:264",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "YouTubeコンテンツプロモーション",
+      "aliases": [
+        "youtube"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:265",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "企業ブランディング",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:266",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "DX戦略",
+      "aliases": [
+        "dx"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:267",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AI駆動開発 (AI-driven development)",
+      "aliases": [
+        "ai駆動開発",
+        "ai-driven",
+        "development",
+        "ai",
+        "driven"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:268",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Claude Code / Cursor",
+      "aliases": [
+        "claude",
+        "code",
+        "cursor"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:269",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "MCP・AIエージェント活用",
+      "aliases": [
+        "mcp",
+        "aiエージェント活用",
+        "ai"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:270",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "SDD × AI駆動開発フロー",
+      "aliases": [
+        "sdd",
+        "ai駆動開発フロー",
+        "ai"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:271",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ポスティング業界のビジネスモデルとイノベーション",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:272",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AWSアーキテクチャ設計",
+      "aliases": [
+        "aws"
+      ],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:273",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "プロジェクトマネジメント",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:274",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "技術的理想と事業的理想の合意形成",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:275",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "評価軸の言語化とトレードオフの合意",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:276",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "技術的負債と事業成長のバランス",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:277",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "プロダクトマネジメントとアーキテクチャの関係",
+      "aliases": [],
+      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:278",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "貢献",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:279",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "ウェルビーイング",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:280",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "長期的な活躍",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:281",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "社員の健康",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:282",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "人材獲得",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:283",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "企業成長",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:284",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "コミュニティ形成",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:285",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "情報共有",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:286",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "学習機会の提供",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:287",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "協調",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:288",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "チームワーク",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:289",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "成長",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:290",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "事業発展",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:291",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "インクルージョン",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:292",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "イベントの質向上",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:293",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "参加者満足度向上",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:294",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "外部知見共有",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:295",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "ブランド価値",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:296",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "革新",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:297",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "DX",
+      "aliases": [
+        "dx"
+      ],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:298",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "AI活用",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:299",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "技術的成長",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:300",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "技術とビジネスの調和",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:301",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "実践的学習",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:302",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "社員の健康やコンディションが向上するプログラムの導入",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:303",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "組織全体のパフォーマンス向上への貢献",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:304",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "優秀な人材獲得による組織力向上",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:305",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "社員間の交流が促進されること",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:306",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "社員が安心して参加できる居場所が作られること",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:307",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい知識や情報の共有による貢献",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:308",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "企画した取り組みが成功し、参加者や利用者に価値を提供できた時",
+      "aliases": [
+        "企画した取り組みが成功し",
+        "参加者や利用者に価値を提供できた時"
+      ],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:309",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "会社の事業発展に貢献できること",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:310",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "イベントの企画・運営を通じて社内の一体感が高まること",
+      "aliases": [
+        "イベントの企画",
+        "運営を通じて社内の一体感が高まること"
+      ],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:311",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "参加者からの良いフィードバックやイベントの成功",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:312",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "外部への情報発信が成功し、企業ブランド価値が向上した時",
+      "aliases": [
+        "外部への情報発信が成功し",
+        "企業ブランド価値が向上した時"
+      ],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:313",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "有益な情報の共有によって社員の学習・成長を促すこと",
+      "aliases": [
+        "有益な情報の共有によって社員の学習",
+        "成長を促すこと"
+      ],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:314",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "最先端の技術やビジネスモデルを探求し、共有すること",
+      "aliases": [
+        "最先端の技術やビジネスモデルを探求し",
+        "共有すること"
+      ],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:315",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "社員の技術スキルが向上すること",
+      "aliases": [],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:316",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:貴志雪乃",
+      "employeeName": "貴志雪乃",
+      "slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "複雑な技術的・事業的課題が解決されること",
+      "aliases": [
+        "複雑な技術的",
+        "事業的課題が解決されること"
+      ],
+      "evidence": "組織への多角的な貢献、社員の心身の健康と長期的な活躍を重視するウェルビーイングの推進に加え、会社の成長を支える優秀な人材の獲得、社員間のインクルーシブな交流を通じたコミュニティ形成、そして外部へのビジネス知見共有、学習機会の提供、ブランド向上にも高い価値を置く。特に、質の高い情報を提供することで社員の成長を促し、技術的専門知識の深化、技術と事業の調和、企業…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:317",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "深い理解力",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:318",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "知的好奇心",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:319",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ビジネスモデル分析能力",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:320",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "計画性",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:321",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自己管理能力",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:322",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "社交性",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:323",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報共有能力",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:324",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "組織活性化への貢献",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:325",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "責任感",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:326",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "親しみやすいコミュニケーション",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:327",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "行動力",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:328",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ポジティブな影響力",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:329",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ネットワーキング",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:330",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "観察力",
+      "aliases": [],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:work_style:331",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "現象の裏にある構造やロジックを深く理解しようとする思考スタイルを持ちます。ラーメン店の立地から「ビジネスモデル」を推察し、「気づきがありました」と考察を共有するなど、表面的な情報だけでなく、その背景にある原理を解明しようとします。自身の体…",
+      "aliases": [
+        "現象の裏にある構造やロジックを深く理解しようとする思考スタイルを持ちます",
+        "ラーメン店の立地から",
+        "ビジネスモデル",
+        "を推察し",
+        "気づきがありました",
+        "と考察を共有するなど",
+        "表面的な情報だけでなく",
+        "その背景にある原理を解明しようとします"
+      ],
+      "evidence": "物事を深く理解し、その背景にある構造やビジネスモデルを考察する知的なアプローチを持ちます。社内イベントや異部署との交流を積極的に活用し、人脈形成と情報収集に努めることで、組織全体の活性化に貢献します。自身の健康や行動計画においても自己管理能力が高く、責任感を持って業務や自己改善に取り組みます。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:332",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "理想の組織像と組織の成長",
+      "aliases": [],
+      "evidence": "直近では、理想の組織像への強い期待と、社内懇親会や本社オフィス訪問を通じた積極的な交流が際立っています。個人の健康管理にも意識が高く、食生活の見直しを検討するなど、自己改善に前向きです。全体的に、前向きで社交的、かつ知的好奇心に溢れた状態が見受けられます。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:333",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "社内懇親会や異部署との交流",
+      "aliases": [],
+      "evidence": "直近では、理想の組織像への強い期待と、社内懇親会や本社オフィス訪問を通じた積極的な交流が際立っています。個人の健康管理にも意識が高く、食生活の見直しを検討するなど、自己改善に前向きです。全体的に、前向きで社交的、かつ知的好奇心に溢れた状態が見受けられます。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:334",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "本社オフィスの利用促進",
+      "aliases": [],
+      "evidence": "直近では、理想の組織像への強い期待と、社内懇親会や本社オフィス訪問を通じた積極的な交流が際立っています。個人の健康管理にも意識が高く、食生活の見直しを検討するなど、自己改善に前向きです。全体的に、前向きで社交的、かつ知的好奇心に溢れた状態が見受けられます。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:335",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "写真・ビジュアルコンテンツ",
+      "aliases": [
+        "写真",
+        "ビジュアルコンテンツ"
+      ],
+      "evidence": "直近では、理想の組織像への強い期待と、社内懇親会や本社オフィス訪問を通じた積極的な交流が際立っています。個人の健康管理にも意識が高く、食生活の見直しを検討するなど、自己改善に前向きです。全体的に、前向きで社交的、かつ知的好奇心に溢れた状態が見受けられます。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:336",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "流行の食文化（ラーメン）とビジネスモデル",
+      "aliases": [
+        "流行の食文化",
+        "ラーメン",
+        "とビジネスモデル"
+      ],
+      "evidence": "直近では、理想の組織像への強い期待と、社内懇親会や本社オフィス訪問を通じた積極的な交流が際立っています。個人の健康管理にも意識が高く、食生活の見直しを検討するなど、自己改善に前向きです。全体的に、前向きで社交的、かつ知的好奇心に溢れた状態が見受けられます。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:337",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "健康的な食生活と自己管理",
+      "aliases": [],
+      "evidence": "直近では、理想の組織像への強い期待と、社内懇親会や本社オフィス訪問を通じた積極的な交流が際立っています。個人の健康管理にも意識が高く、食生活の見直しを検討するなど、自己改善に前向きです。全体的に、前向きで社交的、かつ知的好奇心に溢れた状態が見受けられます。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:338",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "サウナ",
+      "aliases": [],
+      "evidence": "直近では、理想の組織像への強い期待と、社内懇親会や本社オフィス訪問を通じた積極的な交流が際立っています。個人の健康管理にも意識が高く、食生活の見直しを検討するなど、自己改善に前向きです。全体的に、前向きで社交的、かつ知的好奇心に溢れた状態が見受けられます。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:339",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "徹底的な理解",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:340",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "知的好奇心",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:341",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "組織の未来への貢献",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:342",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "社内交流とネットワーキング",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:343",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "健康意識と自己管理",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:344",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "協調性",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:345",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "正直さ",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:346",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "感謝",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:347",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "ポジティブな影響",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:348",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "探究心",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:349",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "組織の成長や理想的な姿について考察し、貢献すること",
+      "aliases": [
+        "組織の成長や理想的な姿について考察し",
+        "貢献すること"
+      ],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:350",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "日常の出来事や流行からビジネスモデルなどの新しい学びや気づきを得ること",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:351",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "異部署の社員や普段関わりの少ない人との交流を通じて新たな視点を得ること",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:352",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の健康管理を適切に行い、自己改善に取り組むこと",
+      "aliases": [
+        "自身の健康管理を適切に行い",
+        "自己改善に取り組むこと"
+      ],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:353",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "ポジティブな体験や発見を他者と共有し、その喜びや価値を広めること",
+      "aliases": [
+        "ポジティブな体験や発見を他者と共有し",
+        "その喜びや価値を広めること"
+      ],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:354",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "他者からの感謝や賞賛を受け、貢献が認められること",
+      "aliases": [
+        "他者からの感謝や賞賛を受け",
+        "貢献が認められること"
+      ],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:355",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上遼太郎",
+      "employeeName": "上遼太郎",
+      "slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "カジュアルな交流を通じて関係性を深めること",
+      "aliases": [],
+      "evidence": "物事の本質を深く理解し、それを自身の言葉で説明できるレベルまで落とし込むことに価値を見出します。組織の理想的な未来像を追求し、その実現に貢献することに強いモチベーションを感じています。また、社内での活発な交流やコミュニティ活動、自身の健康と自己改善を非常に重視し、チーム全体のエンゲージメントと活気を高めることに喜びを感じます。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:356",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "問題解決",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:357",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "協調性",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:358",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "貢献意欲",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:359",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "学習意欲",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:360",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "変革志向",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:361",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実行力",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:362",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報共有",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:363",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "戦略的思考",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:364",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "効率化推進",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:365",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "品質重視",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:366",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実験と検証",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:367",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "好奇心",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:368",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ユーザー視点",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:369",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "計画性",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:370",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自律性",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:371",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "システム設計",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:372",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自動化推進",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:373",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ユーザー中心設計",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:374",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "スケーラビリティ志向",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:375",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "技術選定",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:376",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ビジネス洞察",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:377",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "迅速な意思決定",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:378",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "リスク管理",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:379",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "アーキテクチャ設計",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:380",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "運用設計",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:381",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "検証能力",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:382",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "データモデリング",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:383",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "語彙統制",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:384",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "運用管理",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:385",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "デバッグ/診断",
+      "aliases": [
+        "デバッグ",
+        "診断"
+      ],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:386",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "比較分析",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:387",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "改善提案",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:388",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "長期的視点",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:389",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自己管理",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:390",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AI駆動開発",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:391",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "属人化排除",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:392",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ドキュメント整備",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:393",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "構造化思考",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:394",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ビジョナリー",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:395",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "合意形成",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:396",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "リモートワーク推進",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:397",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "柔軟な働き方実践",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:398",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "リスク識別",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:399",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "課題特定",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:400",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "システム実装",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:401",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ドキュメント化",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:402",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "感謝",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:403",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "適応力",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:404",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "率先垂範",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:405",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "技術的洞察",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:406",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ビジネス戦略理解",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:407",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コスト最適化",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:408",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "インフラ知識",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:409",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ヒアリング力",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:410",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "現実的判断",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:411",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報整理",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:412",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "疑問形成力",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:413",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コンテキスト理解",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:414",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "言語化能力",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:415",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "論理的思考",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:416",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "影響力",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_style:417",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "技術的な課題解決において、Well-Architectedの理想と納期や予算といった「現場の制約」を考慮し、ヒアリングを重視して最適な判断を導き出す現実的なアプローチを取る。自動化やコスト最適化についても、短期的な視点だけでなく長期的な影…",
+      "aliases": [
+        "技術的な課題解決において",
+        "well-architectedの理想と納期や予算といった",
+        "現場の制約",
+        "を考慮し",
+        "ヒアリングを重視して最適な判断を導き出す現実的なアプローチを取る",
+        "自動化やコスト最適化についても",
+        "短期的な視点だけでなく長期的な影",
+        "well"
+      ],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_topic:418",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "インフラ自動化の最適判断と実装戦略",
+      "aliases": [],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_topic:419",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "ビジネス戦略と技術的判断の融合（特に上位レイヤーの思考）",
+      "aliases": [
+        "ビジネス戦略と技術的判断の融合",
+        "特に上位レイヤーの思考"
+      ],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_topic:420",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AIを活用した情報翻訳と伝達の重要性",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "AI駆動開発の推進に加え、アーキテクチャの合意形成、自動化、コスト最適化といったインフラ領域の深い知見とビジネス視点を融合させ、戦略的な意思決定に貢献しようとする。複雑な情報を構造化し、実践的な課題解決を追求する。自身の学習した内容を積極的に他者に共有し、組織全体の知見向上にも貢献しようとする。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:421",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "アーキテクチャの合意形成術（現場の制約と理想のバランス）",
+      "aliases": [
+        "アーキテクチャの合意形成術",
+        "現場の制約と理想のバランス"
+      ],
+      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:422",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "インフラ自動化の最適判断と実装戦略",
+      "aliases": [],
+      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:423",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "クラウドコスト最適化におけるエンジニアの主導権とビジネス戦略",
+      "aliases": [],
+      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:424",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ビジネス戦略と技術的判断の融合（特に上位レイヤーの思考）",
+      "aliases": [
+        "ビジネス戦略と技術的判断の融合",
+        "特に上位レイヤーの思考"
+      ],
+      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:425",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AIを活用した情報翻訳と伝達の重要性",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:426",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "SESとしての立場から見た事業全体の視点",
+      "aliases": [
+        "ses"
+      ],
+      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:427",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "継続可能性（サスティナビリティ）",
+      "aliases": [
+        "継続可能性",
+        "サスティナビリティ"
+      ],
+      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:428",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "貢献",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:429",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "成長",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:430",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "変革",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:431",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "効率化",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:432",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "品質",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:433",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "実用性",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:434",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "実験と検証",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:435",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "共創",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:436",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "探求",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:437",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "チームワーク",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:438",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "ユーザー体験",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:439",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "透明性",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:440",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "自動化",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:441",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "スケーラビリティ",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:442",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "継続的改善",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:443",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "先見性",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:444",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "費用対効果",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:445",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "ビジネス戦略",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:446",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "リスク管理",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:447",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "標準化",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:448",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "適応",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:449",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "成長意欲",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:450",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "AI活用",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:451",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "属人化排除",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:452",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "情報統制",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:453",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "合意形成",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:454",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "持続可能性",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:455",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "柔軟な働き方",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:456",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "挑戦",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:457",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "感謝",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:458",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "率先垂範",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:459",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "多様な働き方",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:460",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "戦略的思考",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:461",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "ビジネス価値",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:462",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "現場理解",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:463",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "エンジニアの責任",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:464",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "実践的知識",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:465",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "影響力行使（エンジニアの）",
+      "aliases": [
+        "影響力行使",
+        "エンジニアの"
+      ],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:466",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "プロアクティブ",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:467",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "責任感",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:468",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "組織の成長",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:469",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自己成長",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:470",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "現状打破",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:471",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "技術革新",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:472",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい技術の実践と検証",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:473",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームの活性化",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:474",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "課題の発見と解決",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:475",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "ユーザーの利便性向上",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:476",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "経営層への貢献",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:477",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "具体的な成果の創出",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:478",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "複雑な技術課題の解決",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:479",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自動化による効率向上",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:480",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "長期的なシステム運用設計",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:481",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "プロジェクトの具現化",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:482",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "ビジネス価値の創出",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:483",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "戦略的課題の解決",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:484",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "組織変革への貢献",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:485",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "ユーザーの使いやすさの実現",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:486",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "AI駆動開発の推進",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:487",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "ドキュメント整備と標準化",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:488",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "知識の体系化",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:489",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "属人化の解消",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:490",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい働き方の確立",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:491",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "リモートワークの可能性実証",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:492",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "同僚への貢献と感謝の還元",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:493",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "技術とビジネスの融合",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:494",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "戦略的な意思決定への貢献",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:495",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "エンジニアの影響力拡大",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:496",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "複雑な技術課題の実践的解決",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:497",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "エンジニアのビジネス貢献",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:498",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "戦略的課題解決への参画",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:499",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "現実と理想のギャップ埋め",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:500",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小松田真伍",
+      "employeeName": "小松田真伍",
+      "slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "知識の社会還元",
+      "aliases": [],
+      "evidence": "技術的な探求心に加え、アーキテクチャ設計、自動化、コスト最適化といったインフラ領域がビジネス戦略に与える影響を深く理解し、エンジニアがその主導権を持つべきだと考えている。現場の制約を考慮した実用性と、組織への貢献、自身の成長に強いモチベーションを感じる。技術を「人に翻訳して渡す」ことで、より広範な価値創出を目指し、自らの立場を超えて全体最適に貢献しようとす…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:501",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "学習意欲",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:502",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "プロアクティブなコミュニケーション能力",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:503",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "協調性",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:504",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "貢献意欲",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:505",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "責任感",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:506",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "関係構築力",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:507",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "前向きな業務遂行",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:508",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報収集力",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:509",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "学習の粘り強さ",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:510",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "内省的学習",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:511",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自己開示力",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:512",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "共感力",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:513",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "協働意欲",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:work_style:514",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "IT未経験という状況から、まず「先輩方から学べることは全て学び」という姿勢で、経験豊富なメンバーからの知識吸収を最優先する点は変わらず、特に新入社員として周囲からのインプットを重視する。過去のリーダー経験から、多様な意見を統合し、調整しな…",
+      "aliases": [
+        "it未経験という状況から",
+        "まず",
+        "先輩方から学べることは全て学び",
+        "という姿勢で",
+        "経験豊富なメンバーからの知識吸収を最優先する点は変わらず",
+        "特に新入社員として周囲からのインプットを重視する",
+        "過去のリーダー経験から",
+        "多様な意見を統合し"
+      ],
+      "evidence": "入社3ヶ月目の新人として、積極的に自己開示とコミュニケーションを図り、周囲との良好な関係構築を最優先に進める。高い学習意欲と成長へのコミットメントを持ち、自身の知識や経験を活かしつつ、チームへの貢献を目指す。未経験分野にも前向きに取り組み、周囲からの学びを積極的に取り入れながら、着実に業務を遂行しようとする。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:515",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "葬送のフリーレン",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:516",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ディズニープラス",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:517",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "アニメ",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:518",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Youtubeでの動画視聴",
+      "aliases": [
+        "youtube"
+      ],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:519",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "歴史（特に古代史と、英語や理数に学習意欲が吸われたこと）",
+      "aliases": [
+        "歴史",
+        "特に古代史と",
+        "英語や理数に学習意欲が吸われたこと"
+      ],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:520",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "自身の年齢（23歳）",
+      "aliases": [
+        "自身の年齢",
+        "23歳",
+        "23"
+      ],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:521",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "新入社員としての成長と協働",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:522",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "新しい同僚（山田さん）との関係構築",
+      "aliases": [
+        "新しい同僚",
+        "山田さん",
+        "との関係構築"
+      ],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:523",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ビジネス書",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:524",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "将棋",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:525",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ポケモン（ゲーム・カード）",
+      "aliases": [
+        "ポケモン",
+        "ゲーム",
+        "カード"
+      ],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:526",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ラーメン",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:527",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "同僚との共通の出身地や趣味",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:528",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "マッサージ巡り",
+      "aliases": [],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:529",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Slerとコンサルティングファームのポジション",
+      "aliases": [
+        "sler"
+      ],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:530",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "専門的なレターの内容（深い理解）",
+      "aliases": [
+        "専門的なレターの内容",
+        "深い理解"
+      ],
+      "evidence": "入社3ヶ月目の新入社員として、新しい環境への適応と人間関係の構築に積極的に取り組んでいる。自己開示と共通の話題を通じて周囲との親近感を深めつつ、自身の成長とチームへの貢献意欲を高く持っている。専門的な学習だけでなく、趣味を通じた交流にも意欲的である。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:531",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "協調性",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:532",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "成長",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:533",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "貢献",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:534",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "責任",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:535",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "探究心",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:536",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "良好な関係性",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:537",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "挑戦",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:538",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "粘り強い学習",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:539",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "協働",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:540",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "親密性",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:541",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "周囲からの感謝や肯定的な反応",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:542",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい知識の習得とスキルの向上",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:543",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームへの貢献と成功",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:544",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "共通の関心事を通じた良好な人間関係",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:545",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自己の成長実感",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:546",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "担当業務の円滑な進行と成果",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:547",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい経験への挑戦と達成",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:548",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "複雑な概念の深い理解",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:549",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "共通の話題による親近感",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:550",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:小島遼祐",
+      "employeeName": "小島遼祐",
+      "slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "相互理解と協働の機会",
+      "aliases": [],
+      "evidence": "人間関係の調和と周囲への貢献、特に、入社3ヶ月目の新人としての自己成長とチームとの協働を非常に重視する。チームの一員として認められ、役立つことや、共通の関心事を通じて良好な関係を築くことに大きな喜びを感じる。新しい知識の習得や深い理解に価値を置き、それを楽しむ傾向がある。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:551",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実務遂行力",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:552",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "責任感",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:553",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報共有の徹底",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:554",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "正確性へのこだわり",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:555",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "リスク管理",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:556",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "人間関係構築力",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:557",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報整理能力",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:558",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "透明性の確保",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:559",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "新入社員オンボーディング支援",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:560",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コンプライアンス遵守",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:561",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "個別への配慮",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:562",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "共感力",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:563",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ユーモア",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:564",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "状況対応力",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:565",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コミュニケーション促進",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:566",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "心理的安全性確保",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:567",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "親近感の醸成",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:568",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実務支援力",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:569",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "環境適応支援",
+      "aliases": [],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:work_style:570",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "問題の発生を未然に防ぐため、必要な手続きに関する具体的な要件を明確に提示し、円滑な業務遂行を支援する。また、新しいメンバーや個人の特性に合わせた丁寧な声かけを通じて、組織への適応を促し、潜在的な不安や問題の解消を図る。",
+      "aliases": [
+        "問題の発生を未然に防ぐため",
+        "必要な手続きに関する具体的な要件を明確に提示し",
+        "円滑な業務遂行を支援する",
+        "また",
+        "新しいメンバーや個人の特性に合わせた丁寧な声かけを通じて",
+        "組織への適応を促し",
+        "潜在的な不安や問題の解消を図る"
+      ],
+      "evidence": "組織運営に必要な事務処理の正確性と透明性を確保しつつ、個人の多様な関心や状況に配慮したコミュニケーションを重視する。ユーモアを交えた私的な体験の共有を通じて親近感を醸成し、ポジティブで心理的安全性の高い職場環境の構築に貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:571",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "就労証明書などの事務手続き",
+      "aliases": [],
+      "evidence": "5月下旬においても、専門的な総務業務に関する詳細な案内を行う一方で、個人の趣味に合わせた歓迎メッセージや、家族のユーモラスな体験の共有を通じて、人間関係の構築と心理的安全性の確保に継続して取り組んでいる。業務と個人の双方において積極的で、ポジティブな職場環境を維持・発展させている。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:572",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "次男の七五三撮影",
+      "aliases": [],
+      "evidence": "5月下旬においても、専門的な総務業務に関する詳細な案内を行う一方で、個人の趣味に合わせた歓迎メッセージや、家族のユーモラスな体験の共有を通じて、人間関係の構築と心理的安全性の確保に継続して取り組んでいる。業務と個人の双方において積極的で、ポジティブな職場環境を維持・発展させている。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:573",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "新しいメンバーとの共通の趣味（ポケモン）",
+      "aliases": [
+        "新しいメンバーとの共通の趣味",
+        "ポケモン"
+      ],
+      "evidence": "5月下旬においても、専門的な総務業務に関する詳細な案内を行う一方で、個人の趣味に合わせた歓迎メッセージや、家族のユーモラスな体験の共有を通じて、人間関係の構築と心理的安全性の確保に継続して取り組んでいる。業務と個人の双方において積極的で、ポジティブな職場環境を維持・発展させている。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:574",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "社内交流の促進",
+      "aliases": [],
+      "evidence": "5月下旬においても、専門的な総務業務に関する詳細な案内を行う一方で、個人の趣味に合わせた歓迎メッセージや、家族のユーモラスな体験の共有を通じて、人間関係の構築と心理的安全性の確保に継続して取り組んでいる。業務と個人の双方において積極的で、ポジティブな職場環境を維持・発展させている。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:575",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "同僚との個人的な交流",
+      "aliases": [],
+      "evidence": "5月下旬においても、専門的な総務業務に関する詳細な案内を行う一方で、個人の趣味に合わせた歓迎メッセージや、家族のユーモラスな体験の共有を通じて、人間関係の構築と心理的安全性の確保に継続して取り組んでいる。業務と個人の双方において積極的で、ポジティブな職場環境を維持・発展させている。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:576",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "正確性",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:577",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "効率性",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:578",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "秩序",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:579",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "貢献",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:580",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "協調性",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:581",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "公正性",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:582",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "透明性",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:583",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "人間関係",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:584",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "親しみやすさ",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:585",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "情報公開",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:586",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "受容",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:587",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "コンプライアンス",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:588",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "個別への配慮",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:589",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "共感",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:590",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "好奇心",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:591",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "多様性の尊重",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:592",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "楽しさ",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:593",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "遊び心",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:594",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "包容力",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:595",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "一体感",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:596",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "家族",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:597",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "繋がり",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:598",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "実用性",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:599",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "サポート",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:600",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "業務プロセスの改善と明確化",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:601",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "情報共有の徹底による混乱防止",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:602",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "社員からの信頼獲得とサポートへの貢献",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:603",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "他者との共感・交流",
+      "aliases": [
+        "他者との共感",
+        "交流"
+      ],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:604",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "制度理解の促進",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:605",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しいメンバーの組織への定着支援",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:606",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "個人の興味や好奇心の追求",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:607",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "個人の能力や経験の尊重",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:608",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "職場の雰囲気向上",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:609",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームのモチベーション向上",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:610",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しいメンバーの円滑な職場適応",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:611",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "心理的安全性のある職場環境の創造",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:612",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "個人的な体験や感情の共有",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:613",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "実務支援",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:614",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:藤井芙美子",
+      "employeeName": "藤井芙美子",
+      "slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "円滑な手続きの促進",
+      "aliases": [],
+      "evidence": "組織における業務の正確性と公正な運用を重視しつつも、個人の個性や背景を尊重し、温かい人間関係と親近感を築くことに大きな価値を見出す。個人的な体験やユーモアを共有することで、日々の業務や交流に楽しさや遊び心を見出し、ポジティブな職場環境の醸成に貢献している。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:615",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "技術的なスキル（VB.Net, JAVA）",
+      "aliases": [
+        "技術的なスキル",
+        "vb",
+        "net",
+        "java"
+      ],
+      "evidence": "システム開発、品質管理の経験に加え、AI技術活用と応用力に長ける。工夫を凝らしたコーディングを好み、多角的な視点から問題解決に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:616",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "品質管理の経験と視点",
+      "aliases": [],
+      "evidence": "システム開発、品質管理の経験に加え、AI技術活用と応用力に長ける。工夫を凝らしたコーディングを好み、多角的な視点から問題解決に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:617",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AI活用スキルと探求心",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "システム開発、品質管理の経験に加え、AI技術活用と応用力に長ける。工夫を凝らしたコーディングを好み、多角的な視点から問題解決に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:618",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "旺盛な学習意欲と知識応用力",
+      "aliases": [],
+      "evidence": "システム開発、品質管理の経験に加え、AI技術活用と応用力に長ける。工夫を凝らしたコーディングを好み、多角的な視点から問題解決に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:619",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "工夫を凝らすコーディングへの興味",
+      "aliases": [],
+      "evidence": "システム開発、品質管理の経験に加え、AI技術活用と応用力に長ける。工夫を凝らしたコーディングを好み、多角的な視点から問題解決に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:620",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "チームとの協働を重視する姿勢",
+      "aliases": [],
+      "evidence": "システム開発、品質管理の経験に加え、AI技術活用と応用力に長ける。工夫を凝らしたコーディングを好み、多角的な視点から問題解決に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:work_style:621",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "IT企業でのシステム開発経験から論理的思考力を持ち、AIに質問することで多角的な視点や効率的な解決策を模索する。読書で得た多様な知識（例: コーヒーの化学、戦略論）を業務や会話に応用しようとする姿勢も見られる。",
+      "aliases": [
+        "it企業でのシステム開発経験から論理的思考力を持ち",
+        "aiに質問することで多角的な視点や効率的な解決策を模索する",
+        "読書で得た多様な知識",
+        "コーヒーの化学",
+        "戦略論",
+        "を業務や会話に応用しようとする姿勢も見られる",
+        "it",
+        "ai"
+      ],
+      "evidence": "システム開発、品質管理の経験に加え、AI技術活用と応用力に長ける。工夫を凝らしたコーディングを好み、多角的な視点から問題解決に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:work_topic:622",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AI技術の活用（旅行計画、献立作成、コード生成）",
+      "aliases": [
+        "ai技術の活用",
+        "旅行計画",
+        "献立作成",
+        "コード生成",
+        "ai"
+      ],
+      "evidence": "システム開発、品質管理の経験に加え、AI技術活用と応用力に長ける。工夫を凝らしたコーディングを好み、多角的な視点から問題解決に取り組む。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:623",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AI技術の活用（旅行計画、献立作成、コード生成）",
+      "aliases": [
+        "ai技術の活用",
+        "旅行計画",
+        "献立作成",
+        "コード生成",
+        "ai"
+      ],
+      "evidence": "入社直後で、開発者としての復帰とチームとの協働に非常に前向きである。AI技術への関心は非常に高く、読書を通じて多様な知識を吸収し、それを業務やコミュニケーションに活かそうとしている。人との交流も積極的に楽しみ、新しい環境での活躍を強く望んでいる。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:624",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "読書（「コーヒーの化学」、「君は戦略を立てることができるか」など幅広いジャンル）",
+      "aliases": [
+        "読書",
+        "コーヒーの化学",
+        "君は戦略を立てることができるか",
+        "など幅広いジャンル"
+      ],
+      "evidence": "入社直後で、開発者としての復帰とチームとの協働に非常に前向きである。AI技術への関心は非常に高く、読書を通じて多様な知識を吸収し、それを業務やコミュニケーションに活かそうとしている。人との交流も積極的に楽しみ、新しい環境での活躍を強く望んでいる。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:625",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "コードの書き方や工夫",
+      "aliases": [],
+      "evidence": "入社直後で、開発者としての復帰とチームとの協働に非常に前向きである。AI技術への関心は非常に高く、読書を通じて多様な知識を吸収し、それを業務やコミュニケーションに活かそうとしている。人との交流も積極的に楽しみ、新しい環境での活躍を強く望んでいる。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:626",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "チームメンバーとの交流と協力",
+      "aliases": [],
+      "evidence": "入社直後で、開発者としての復帰とチームとの協働に非常に前向きである。AI技術への関心は非常に高く、読書を通じて多様な知識を吸収し、それを業務やコミュニケーションに活かそうとしている。人との交流も積極的に楽しみ、新しい環境での活躍を強く望んでいる。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:627",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "新しい案件やプロジェクトへの参加",
+      "aliases": [],
+      "evidence": "入社直後で、開発者としての復帰とチームとの協働に非常に前向きである。AI技術への関心は非常に高く、読書を通じて多様な知識を吸収し、それを業務やコミュニケーションに活かそうとしている。人との交流も積極的に楽しみ、新しい環境での活躍を強く望んでいる。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:628",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "技術的成長とスキル向上",
+      "aliases": [],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:629",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "チームワークと貢献",
+      "aliases": [],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:630",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "新しい知識の探求と学習",
+      "aliases": [],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:631",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "AI技術の積極的活用",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:632",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "人とのつながり、交流",
+      "aliases": [
+        "人とのつながり",
+        "交流"
+      ],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:633",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "開発者としての能力回復と向上",
+      "aliases": [],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:634",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームメンバーとの協働によるシステム開発",
+      "aliases": [],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:635",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "AIを活用した新しい働き方や効率化の実現",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:636",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "読書などによる知的好奇心の充足と知識の獲得",
+      "aliases": [],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:637",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:菅野聖也",
+      "employeeName": "菅野聖也",
+      "slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "積極的に人々と交流し、関係を深めること",
+      "aliases": [
+        "積極的に人々と交流し",
+        "関係を深めること"
+      ],
+      "evidence": "新しい技術の習得と自身の成長を強く志向し、AI技術の可能性を信じてその活用を推進する。チームの一員として貢献することに価値を見出し、知的探求と人との交流を大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:638",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "起業家精神",
+      "aliases": [],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:639",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実践的なAI活用能力",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:640",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "グローバルな視点",
+      "aliases": [],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:641",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "アウトプット志向",
+      "aliases": [],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:642",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実行力",
+      "aliases": [],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:643",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "協調的リーダーシップ",
+      "aliases": [],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:644",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "最新技術の探求と検証",
+      "aliases": [],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_style:645",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "最新のAI技術（特に小型高性能モデル）を深く理解し、自身のMac M4 Max環境でのGPTsoss動作検証など実践的な活用方法を模索・提案することで、現場の課題解決に貢献する。「現場で使い倒せるAIを一緒に形にしましょう」と、共創を通じ…",
+      "aliases": [
+        "最新のai技術",
+        "特に小型高性能モデル",
+        "を深く理解し",
+        "自身のmac",
+        "m4",
+        "max環境でのgptsoss動作検証など実践的な活用方法を模索",
+        "提案することで",
+        "現場の課題解決に貢献する"
+      ],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:646",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "小型高性能AIモデルの動向と実用性（DeepSeek4を含む）",
+      "aliases": [
+        "小型高性能aiモデルの動向と実用性",
+        "deepseek4を含む",
+        "ai",
+        "deepseek4"
+      ],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:647",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "Mac環境でのAI活用（M4 Max、GPTsoss、Mac Studioでの動作可能性）",
+      "aliases": [
+        "mac環境でのai活用",
+        "m4",
+        "max",
+        "gptsoss",
+        "mac",
+        "studioでの動作可能性",
+        "ai",
+        "studio"
+      ],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:648",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "海外AIスタートアップとの連携",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:649",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "国際的なチーム開発",
+      "aliases": [],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:650",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "コスト効率の良いAIソリューション",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "グローバルな視点と実践的なAI知識を強みとし、起業家精神と行動力で事業を推進する。最新技術を自ら積極的に検証し、その知見を共有しながら、多様なチームとの共創を通じて具体的な成果を最大化する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:651",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "小型高性能AIモデルの動向と実用性（DeepSeek4を含む）",
+      "aliases": [
+        "小型高性能aiモデルの動向と実用性",
+        "deepseek4を含む",
+        "ai",
+        "deepseek4"
+      ],
+      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:652",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Mac環境でのAI活用（M4 Max、GPTsoss、Mac Studioでの動作可能性）",
+      "aliases": [
+        "mac環境でのai活用",
+        "m4",
+        "max",
+        "gptsoss",
+        "mac",
+        "studioでの動作可能性",
+        "ai",
+        "studio"
+      ],
+      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:653",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "海外AIスタートアップとの連携",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:654",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "国際的なチーム開発",
+      "aliases": [],
+      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:655",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ハッカソンでのアウトプット創出",
+      "aliases": [],
+      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:656",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "コスト効率の良いAIソリューション",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:657",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "成長",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:658",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "貢献",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:659",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "共創",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:660",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "アウトプット",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:661",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "実践",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:662",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "探求",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:663",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "効率性",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:664",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい技術の習得と実践",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:665",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "海外での多様な経験と異文化交流",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:666",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームとの共創と具体的な成果創出",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:667",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "ハッカソンでのアウトプット創出",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:668",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:佐藤傑",
+      "employeeName": "佐藤傑",
+      "slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "コスト効率の良い技術活用",
+      "aliases": [],
+      "evidence": "新しい技術の探求とその実践的な活用を通じて社会に貢献することに価値を見出す。アウトプットと共創を重視し、常に自己成長と具体的な成果を追求する。異文化交流や旅、効率性も重要な要素。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:669",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ビジョナリーリーダーシップと文化醸成",
+      "aliases": [],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:670",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "プロアクティブなコミュニケーションと関係構築",
+      "aliases": [],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:671",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自己開示による信頼関係の構築",
+      "aliases": [],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:672",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "新メンバーのオンボーディング支援と統合促進",
+      "aliases": [],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:673",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コミュニティビルディングと一体感の醸成",
+      "aliases": [],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:674",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "相手の関心事を引き出す傾聴力",
+      "aliases": [],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:675",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "他者への敬意と称賛を通じたモチベーション向上",
+      "aliases": [],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:676",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "新メンバーのスキルや興味の積極的な探求",
+      "aliases": [],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:677",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "情報収集力と活用（AIの積極的利用）",
+      "aliases": [
+        "情報収集力と活用",
+        "aiの積極的利用",
+        "ai"
+      ],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:work_style:678",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "仕事上の調整や協力においては、他者の成果を尊重しつつ、自身のサポート体制を明確に提示することで、円滑な連携と問題解決を促進する。また、情報が必要な際にはAIなどのツールを積極的に活用し、迅速かつ効率的に解決策や情報を提供する。",
+      "aliases": [
+        "仕事上の調整や協力においては",
+        "他者の成果を尊重しつつ",
+        "自身のサポート体制を明確に提示することで",
+        "円滑な連携と問題解決を促進する",
+        "また",
+        "情報が必要な際にはaiなどのツールを積極的に活用し",
+        "迅速かつ効率的に解決策や情報を提供する",
+        "ai"
+      ],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:work_topic:679",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AIを活用した情報収集や知識共有",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "自身のビジョンと情熱を明確に伝え、チームの士気を高めながら組織目標達成に貢献するリーダーシップを発揮する。特に、個人的な交流を通じてメンバーの一体感を醸成し、他者の成果を積極的に称賛し協力することで、新しいメンバーの円滑なオンボーディングとチームへの統合に尽力する。情報収集能力も高く、他者の疑問に対しAIを積極的に活用して貢献する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:interest:680",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "家族との交流や子育て（GWの過ごし方、こどもの国、けん玉）",
+      "aliases": [
+        "家族との交流や子育て",
+        "gwの過ごし方",
+        "こどもの国",
+        "けん玉",
+        "gw"
+      ],
+      "evidence": "家族との時間を積極的に楽しみ、その喜びやエピソード（GWの過ごし方、けん玉チャレンジ）をチームと共有する。社内では積極的にコミュニケーションを取り、他者の話にも共感を示す。また、AIを情報収集に活用するなど、新しいツールへの適応力と貢献意欲も高い。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:interest:681",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "グルメ（山岡家などのラーメン店）やリラックス体験（サウナ）",
+      "aliases": [
+        "グルメ",
+        "山岡家などのラーメン店",
+        "やリラックス体験",
+        "サウナ"
+      ],
+      "evidence": "家族との時間を積極的に楽しみ、その喜びやエピソード（GWの過ごし方、けん玉チャレンジ）をチームと共有する。社内では積極的にコミュニケーションを取り、他者の話にも共感を示す。また、AIを情報収集に活用するなど、新しいツールへの適応力と貢献意欲も高い。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:interest:682",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AIを活用した情報収集や知識共有",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "家族との時間を積極的に楽しみ、その喜びやエピソード（GWの過ごし方、けん玉チャレンジ）をチームと共有する。社内では積極的にコミュニケーションを取り、他者の話にも共感を示す。また、AIを情報収集に活用するなど、新しいツールへの適応力と貢献意欲も高い。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:683",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "自己開示と透明性",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:684",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "組織のビジョンと成長への貢献",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:685",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "チームの結束と高い士気",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:686",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "深い人間関係の構築と共感",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:687",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "ポジティブな職場文化の醸成",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:688",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "家族との調和",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:689",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "共有された挑戦と達成感",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:690",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "新メンバーの円滑な統合と支援",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:691",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "共通の興味や経験を通じた関係構築",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:692",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "他者への敬意と成果の承認",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:693",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "新メンバーの多様なスキルや興味への尊重と探求心",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:694",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "情報収集と共有による貢献",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:695",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の想いをチームと共有し、共感を得ること",
+      "aliases": [
+        "自身の想いをチームと共有し",
+        "共感を得ること"
+      ],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:696",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "組織が掲げる「大成功」の実現に向けて貢献すること",
+      "aliases": [
+        "組織が掲げる",
+        "大成功",
+        "の実現に向けて貢献すること"
+      ],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:697",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しいメンバーが円滑にチームに溶け込み、安心して活躍すること",
+      "aliases": [
+        "新しいメンバーが円滑にチームに溶け込み",
+        "安心して活躍すること"
+      ],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:698",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームの一体感とシナジーの創出",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:699",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "ポジティブで協力的な職場環境の維持",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:700",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "仲間と共に個人的な挑戦を乗り越えること",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:701",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "メンバーが積極的にイベントに参加し、楽しんでいる姿を見ること",
+      "aliases": [
+        "メンバーが積極的にイベントに参加し",
+        "楽しんでいる姿を見ること"
+      ],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:702",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "共通の話題や趣味を通じてメンバーと絆を深めること",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:703",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "他者の努力や成果を認め、称賛すること",
+      "aliases": [
+        "他者の努力や成果を認め",
+        "称賛すること"
+      ],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:704",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新メンバーのユニークなスキルや趣味について学ぶこと",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:705",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:鈴木悠斗",
+      "employeeName": "鈴木悠斗",
+      "slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "他者の疑問や困りごとを情報提供によって解決すること",
+      "aliases": [],
+      "evidence": "自身の想いをチームと共有し、組織のビジョン実現に向けて一丸となることに大きな価値を見出す。メンバー個々人との深い人間関係と、ポジティブでオープンな職場文化、他者への称賛と協力、新しいメンバーの円滑な統合、そして共に困難を乗り越える経験が行動の原動力となっている。家族との調和も依然として重要な価値観であり、仕事とプライベートのバランスを大切にする。新しい情報…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:706",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "リーダーシップ",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:707",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "社会課題解決志向",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:708",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "戦略的思考",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:709",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "組織牽引力",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:710",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "実行力",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:711",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "採用力",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:712",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "多様性推進",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:713",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "チームビルディング",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:714",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "エンゲージメント促進",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:715",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "学習促進",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:716",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "先見性",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:717",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "企業文化構築",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:718",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "人材育成サポート",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:719",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "個人への配慮",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:720",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "透明性",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:721",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AI技術導入推進",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:722",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "健康管理意識",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:723",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "内部プロセス改善",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:724",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "イベント企画・運営",
+      "aliases": [
+        "イベント企画",
+        "運営"
+      ],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:725",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "行動変容促進",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:726",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自己挑戦",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:727",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "準備力",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:728",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "戦略的営業",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:729",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "プロ意識",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:730",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "経営哲学の共有",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:731",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ホスピタリティ",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:732",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "急速な組織拡大管理",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:733",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "厳選採用",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:734",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "戦略的M&A推進",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:735",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "高難易度案件獲得",
+      "aliases": [],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_style:736",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "徹底した「準備が9割」の哲学に基づき、綿密な計画と事前準備で困難な目標を達成する。上場SIer社長とのゴルフでの協業機会創出や、実績のないベンチャーがVCから資金調達1.5億円、大型案件獲得に至った成功例として、「資料に語らせる」戦略を具…",
+      "aliases": [
+        "徹底した",
+        "準備が9割",
+        "の哲学に基づき",
+        "綿密な計画と事前準備で困難な目標を達成する",
+        "上場sier社長とのゴルフでの協業機会創出や",
+        "実績のないベンチャーがvcから資金調達1",
+        "5億円",
+        "大型案件獲得に至った成功例として"
+      ],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:737",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "新しく参画した営業部長・人事部長の活躍と幹部への権限委譲",
+      "aliases": [
+        "新しく参画した営業部長",
+        "人事部長の活躍と幹部への権限委譲"
+      ],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:738",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "内定率10%という厳選採用と社風・カルチャーとのマッチ度重視",
+      "aliases": [
+        "内定率10%という厳選採用と社風",
+        "カルチャーとのマッチ度重視",
+        "10"
+      ],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:739",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "上場SIer社長から学んだAI戦略、営業ハック、プロの「準備」、ホスピタリティ",
+      "aliases": [
+        "上場sier社長から学んだai戦略",
+        "営業ハック",
+        "プロの",
+        "準備",
+        "ホスピタリティ",
+        "sier",
+        "ai"
+      ],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:740",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "「準備が9割」という自身の営業哲学と戦略的交渉術",
+      "aliases": [
+        "準備が9割",
+        "という自身の営業哲学と戦略的交渉術"
+      ],
+      "evidence": "「準備が9割」の哲学と厳選採用で組織の急成長を管理し、強固な文化を維持。幹部への権限委譲で自身の時間を戦略的M&A推進や高難易度案件獲得に投じ、高い視座で事業を牽引。自身の経験や学びを積極的に共有し、組織全体のパフォーマンスと持続的成長を力強く促進する。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:741",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "半年前5人から35人（業務委託含め55人）への組織の急拡大",
+      "aliases": [
+        "半年前5人から35人",
+        "業務委託含め55人",
+        "への組織の急拡大",
+        "35",
+        "55"
+      ],
+      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:742",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "新しく参画した営業部長・人事部長の活躍と幹部への権限委譲",
+      "aliases": [
+        "新しく参画した営業部長",
+        "人事部長の活躍と幹部への権限委譲"
+      ],
+      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:743",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "自身の役割を「M&A戦略の推進」や「高難易度な受託案件の獲得」へシフトすること",
+      "aliases": [
+        "自身の役割を",
+        "m&a戦略の推進",
+        "高難易度な受託案件の獲得",
+        "へシフトすること"
+      ],
+      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:744",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "内定率10%という厳選採用と社風・カルチャーとのマッチ度重視",
+      "aliases": [
+        "内定率10%という厳選採用と社風",
+        "カルチャーとのマッチ度重視",
+        "10"
+      ],
+      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:745",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "関東在住メンバー9割参加の懇親会の成功と文化醸成",
+      "aliases": [],
+      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:746",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "上場SIer社長から学んだAI戦略、営業ハック、プロの「準備」、ホスピタリティ",
+      "aliases": [
+        "上場sier社長から学んだai戦略",
+        "営業ハック",
+        "プロの",
+        "準備",
+        "ホスピタリティ",
+        "sier",
+        "ai"
+      ],
+      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:747",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "「準備が9割」という自身の営業哲学と戦略的交渉術",
+      "aliases": [
+        "準備が9割",
+        "という自身の営業哲学と戦略的交渉術"
+      ],
+      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:748",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "社内勉強会を通じたメンバーの学習機会提供",
+      "aliases": [],
+      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:749",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "新たな人材の獲得とチームへの歓迎",
+      "aliases": [],
+      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:750",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "MVVの追求と実践",
+      "aliases": [
+        "mvv"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:751",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "社会課題解決",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:752",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "新しいSIer像の追求",
+      "aliases": [
+        "sier"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:753",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "AI駆動型組織への変革",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:754",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "戦略的投資と意思決定",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:755",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "組織文化の醸成",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:756",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "チームエンゲージメント",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:757",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "人材の成長とサポート",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:758",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "多様性",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:759",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "透明性",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:760",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "信頼関係の構築",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:761",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "共有体験の創出",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:762",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "人とのつながり",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:763",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "責任感",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:764",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "健康管理",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:765",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "効率化と生産性向上 (AIによる)",
+      "aliases": [
+        "効率化と生産性向上",
+        "aiによる",
+        "ai"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:766",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "自己成長と組織貢献の連動",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:767",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "挑戦と限界突破",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:768",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "準備の徹底",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:769",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "プロ意識",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:770",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "経営的執念",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:771",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "ホスピタリティ",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:772",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "経験と学びの共有",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:773",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "急速な組織拡大の戦略的マネジメント",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:774",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "幹部への権限委譲と信頼",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:775",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "M&A戦略の推進",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:776",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "高難易度受託案件の獲得",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:777",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "厳選採用によるカルチャー維持",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:778",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "MVVが組織全体に深く理解され、行動の指針となること",
+      "aliases": [
+        "mvvが組織全体に深く理解され",
+        "行動の指針となること",
+        "mvv"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:779",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "社会課題（例：個別避難計画）を技術で解決し、誰かの幸せに直結すること",
+      "aliases": [
+        "社会課題",
+        "個別避難計画",
+        "を技術で解決し",
+        "誰かの幸せに直結すること"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:780",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "「新しいSIer」として組織が進化し、市場で独自の価値を確立すること",
+      "aliases": [
+        "新しいsier",
+        "として組織が進化し",
+        "市場で独自の価値を確立すること",
+        "sier"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:781",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "AI技術の組織への導入が進み、「AI駆動型組織」が実現すること",
+      "aliases": [
+        "ai技術の組織への導入が進み",
+        "ai駆動型組織",
+        "が実現すること",
+        "ai"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:782",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "徹底した準備が商談やゴルフといった場での成功に繋がり、協業や資金調達といった具体的な成果を生み出すこと",
+      "aliases": [
+        "徹底した準備が商談やゴルフといった場での成功に繋がり",
+        "協業や資金調達といった具体的な成果を生み出すこと"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:783",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "上場SIer社長のような一流の経営者から学び、その知見を組織に還元できること",
+      "aliases": [
+        "上場sier社長のような一流の経営者から学び",
+        "その知見を組織に還元できること",
+        "sier"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:784",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "「Letter of T」を通じて自身の哲学や経験がメンバーに伝わり、組織の成長に貢献すること",
+      "aliases": [
+        "letter",
+        "of",
+        "を通じて自身の哲学や経験がメンバーに伝わり",
+        "組織の成長に貢献すること"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:785",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "社員とその家族、友人を含むメンバーのエンゲージメント向上と交流の活性化",
+      "aliases": [
+        "社員とその家族",
+        "友人を含むメンバーのエンゲージメント向上と交流の活性化"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:786",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "優秀な人材の獲得と新たな仲間が増えること、特に内定率10%という厳選採用で質の高い仲間が増えること",
+      "aliases": [
+        "優秀な人材の獲得と新たな仲間が増えること",
+        "特に内定率10%という厳選採用で質の高い仲間が増えること",
+        "10"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:787",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新規入社者が組織に溶け込み、その成長をサポートできること",
+      "aliases": [
+        "新規入社者が組織に溶け込み",
+        "その成長をサポートできること"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:788",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の企画や発信がメンバーの行動や意識に良い影響を与えること",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:789",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "組織の一体感やポジティブな雰囲気が高まること",
+      "aliases": [],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:790",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の健康を維持し、持続的に貢献できること、それを「経営責任」と捉えること",
+      "aliases": [
+        "自身の健康を維持し",
+        "持続的に貢献できること",
+        "それを",
+        "経営責任",
+        "と捉えること"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:791",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "困難な個人的な挑戦を成功させ、「できない」を「できる」に変えることを証明すること",
+      "aliases": [
+        "困難な個人的な挑戦を成功させ",
+        "できない",
+        "できる",
+        "に変えることを証明すること"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:792",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "組織が急激に成長し、ステージが一段上がる「歴史が変わる瞬間」を体感すること",
+      "aliases": [
+        "組織が急激に成長し",
+        "ステージが一段上がる",
+        "歴史が変わる瞬間",
+        "を体感すること"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:793",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "幹部メンバーに組織の背中を預け、自身がトップにしかできない高難度な戦略的課題（M&A、高難度案件）に集中できること",
+      "aliases": [
+        "幹部メンバーに組織の背中を預け",
+        "自身がトップにしかできない高難度な戦略的課題",
+        "m&a",
+        "高難度案件",
+        "に集中できること"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:794",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:戸塚直道",
+      "employeeName": "戸塚直道",
+      "slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "最高のカルチャーを守りながら、まだ見ぬ高みへと一気に駆け上がること",
+      "aliases": [
+        "最高のカルチャーを守りながら",
+        "まだ見ぬ高みへと一気に駆け上がること"
+      ],
+      "evidence": "「準備が9割」という徹底したプロ意識と、組織の急成長を支える文化醸成への強いコミットメントを核とする。頼れる幹部への権限委譲を通じて自身の時間をM&A戦略や高難易度案件の獲得といった経営の最重要課題に集中させ、事業のステージを一段引き上げることに価値を見出す。厳選採用で最高のカルチャーを維持しつつ、自身の学びや哲学を共有し、チーム全体でまだ見ぬ高みを目指す…",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:795",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "学習意欲",
+      "aliases": [],
+      "evidence": "多様な経験と高い学習意欲に加え、自己規律を持って目標達成に取り組む。コミュニケーション能力も高く、周囲を支援しながら協調的に働くことを志向する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:796",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "コミュニケーション能力",
+      "aliases": [],
+      "evidence": "多様な経験と高い学習意欲に加え、自己規律を持って目標達成に取り組む。コミュニケーション能力も高く、周囲を支援しながら協調的に働くことを志向する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:797",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "適応力",
+      "aliases": [],
+      "evidence": "多様な経験と高い学習意欲に加え、自己規律を持って目標達成に取り組む。コミュニケーション能力も高く、周囲を支援しながら協調的に働くことを志向する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:798",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "協調性",
+      "aliases": [],
+      "evidence": "多様な経験と高い学習意欲に加え、自己規律を持って目標達成に取り組む。コミュニケーション能力も高く、周囲を支援しながら協調的に働くことを志向する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:799",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自己規律",
+      "aliases": [],
+      "evidence": "多様な経験と高い学習意欲に加え、自己規律を持って目標達成に取り組む。コミュニケーション能力も高く、周囲を支援しながら協調的に働くことを志向する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:800",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "目標達成志向",
+      "aliases": [],
+      "evidence": "多様な経験と高い学習意欲に加え、自己規律を持って目標達成に取り組む。コミュニケーション能力も高く、周囲を支援しながら協調的に働くことを志向する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:work_style:801",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "自身の多様な経験を基盤としつつ、未知の分野や課題に対しては「積極的に色々なことを学んでいきたい」と表明するように、周囲との連携を図りながら知識を吸収し解決策を見出すアプローチを取る。個人的な目標に対しても、現状を認識しつつ着実にステップを…",
+      "aliases": [
+        "自身の多様な経験を基盤としつつ",
+        "未知の分野や課題に対しては",
+        "積極的に色々なことを学んでいきたい",
+        "と表明するように",
+        "周囲との連携を図りながら知識を吸収し解決策を見出すアプローチを取る",
+        "個人的な目標に対しても",
+        "現状を認識しつつ着実にステップを"
+      ],
+      "evidence": "多様な経験と高い学習意欲に加え、自己規律を持って目標達成に取り組む。コミュニケーション能力も高く、周囲を支援しながら協調的に働くことを志向する。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:802",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "社内コミュニケーション",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:803",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "チームワーク",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:804",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "日本酒",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:805",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "クレーンゲーム",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:806",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ポケモン",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:807",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "映画",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:808",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "オンライン飲み部",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:809",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ランニング",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:810",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "健康維持",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:811",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "自己鍛錬",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:812",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "長距離イベント",
+      "aliases": [],
+      "evidence": "入社後も継続して自己成長への意欲が高く、新たな個人的な挑戦を始めている。周囲への気配りや応援も忘れず、社内でのポジティブな存在として期待される。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:813",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "チームワーク",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:814",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "自己成長",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:815",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "社内のつながり",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:816",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "多様な経験",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:817",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "好奇心",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:818",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "自己鍛錬",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:819",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい知識やスキルを習得すること",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:820",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "自身の成長を実感できること",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:821",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい経験をすること",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:822",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "目標を達成すること",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:823",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "チームに貢献すること",
+      "aliases": [],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:824",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:榎本詩織",
+      "employeeName": "榎本詩織",
+      "slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "社内の人々と交流し、共に働くこと",
+      "aliases": [
+        "社内の人々と交流し",
+        "共に働くこと"
+      ],
+      "evidence": "チームワークと自己成長を強く重視し、新しい経験やスキルを積極的に習得することに意欲的。目標に向かって努力する過程自体を楽しんでいる。また、社内のつながりや他者への貢献も大切にする。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:825",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "サーバ運用・テスト経験",
+      "aliases": [
+        "サーバ運用",
+        "テスト経験"
+      ],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:826",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "改修開発・サポート経験",
+      "aliases": [
+        "改修開発",
+        "サポート経験"
+      ],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:827",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "総合テストへの対応力",
+      "aliases": [],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:828",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "丁寧な対人姿勢",
+      "aliases": [],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:829",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "学習意欲と適応力",
+      "aliases": [],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_style:830",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "まず現場や相手に合わせて丁寧に状況を理解し、自身の経験を土台に着実に対応するスタイル。不慣れな領域では無理に取り繕わず、学習と質問を通じてキャッチアップする姿勢が強い。",
+      "aliases": [
+        "まず現場や相手に合わせて丁寧に状況を理解し",
+        "自身の経験を土台に着実に対応するスタイル",
+        "不慣れな領域では無理に取り繕わず",
+        "学習と質問を通じてキャッチアップする姿勢が強い"
+      ],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:831",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "サーバ運用",
+      "aliases": [],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:832",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "テスト業務",
+      "aliases": [],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:833",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "改修開発",
+      "aliases": [],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:834",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "総合テスト",
+      "aliases": [],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:835",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "Slackコミュニケーション",
+      "aliases": [
+        "slack"
+      ],
+      "evidence": "長期のサーバ運用・テスト経験を基盤に、改修開発、サポート、総合テストまで幅広く対応できる実務型の技術者。新しい環境では丁寧に状況を把握し、学びながら着実に貢献していくタイプです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:836",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "サーバ運用",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:837",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "テスト業務",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:838",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "改修開発",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:839",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "サポート業務",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:840",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "総合テスト",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:841",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "アニメ",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:842",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "映画鑑賞",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:843",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ゲーム",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:844",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "トミカ収集",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:845",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "映画フライヤー収集",
+      "aliases": [],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:846",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "Slackコミュニケーション",
+      "aliases": [
+        "slack"
+      ],
+      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:847",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "学習と成長",
+      "aliases": [],
+      "evidence": "学び直しと早期貢献、丁寧な人間関係づくり、趣味を通じた交流を大切にしています。Slack上での活発な交流にも価値を感じており、社内のつながりを前向きに受け止めています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:848",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "早期貢献",
+      "aliases": [],
+      "evidence": "学び直しと早期貢献、丁寧な人間関係づくり、趣味を通じた交流を大切にしています。Slack上での活発な交流にも価値を感じており、社内のつながりを前向きに受け止めています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:849",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "丁寧な関係構築",
+      "aliases": [],
+      "evidence": "学び直しと早期貢献、丁寧な人間関係づくり、趣味を通じた交流を大切にしています。Slack上での活発な交流にも価値を感じており、社内のつながりを前向きに受け止めています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:850",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "社内交流",
+      "aliases": [],
+      "evidence": "学び直しと早期貢献、丁寧な人間関係づくり、趣味を通じた交流を大切にしています。Slack上での活発な交流にも価値を感じており、社内のつながりを前向きに受け止めています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:851",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "趣味への探究心",
+      "aliases": [],
+      "evidence": "学び直しと早期貢献、丁寧な人間関係づくり、趣味を通じた交流を大切にしています。Slack上での活発な交流にも価値を感じており、社内のつながりを前向きに受け止めています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:852",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい環境で役に立てること",
+      "aliases": [],
+      "evidence": "学び直しと早期貢献、丁寧な人間関係づくり、趣味を通じた交流を大切にしています。Slack上での活発な交流にも価値を感じており、社内のつながりを前向きに受け止めています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:853",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "技術経験を活かして貢献できること",
+      "aliases": [],
+      "evidence": "学び直しと早期貢献、丁寧な人間関係づくり、趣味を通じた交流を大切にしています。Slack上での活発な交流にも価値を感じており、社内のつながりを前向きに受け止めています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:854",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "Slackで同じ趣味の人と交流できること",
+      "aliases": [
+        "slack"
+      ],
+      "evidence": "学び直しと早期貢献、丁寧な人間関係づくり、趣味を通じた交流を大切にしています。Slack上での活発な交流にも価値を感じており、社内のつながりを前向きに受け止めています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:855",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:上原基臣",
+      "employeeName": "上原基臣",
+      "slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "アニメ・映画・ゲーム・収集などの話題でつながること",
+      "aliases": [
+        "アニメ",
+        "映画",
+        "ゲーム",
+        "収集などの話題でつながること"
+      ],
+      "evidence": "学び直しと早期貢献、丁寧な人間関係づくり、趣味を通じた交流を大切にしています。Slack上での活発な交流にも価値を感じており、社内のつながりを前向きに受け止めています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:856",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AWS運用・監視経験",
+      "aliases": [
+        "aws運用",
+        "監視経験",
+        "aws"
+      ],
+      "evidence": "多様な職務経験とAWS運用・監視経験を持ち、未知の領域でもAIや整理力を使って学習を進められるタイプ。音響や音楽制作の経験から、細部への感覚や継続的な創作力も強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:857",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "多様な職務経験による適応力",
+      "aliases": [],
+      "evidence": "多様な職務経験とAWS運用・監視経験を持ち、未知の領域でもAIや整理力を使って学習を進められるタイプ。音響や音楽制作の経験から、細部への感覚や継続的な創作力も強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:858",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "AIを活用した学習姿勢",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "多様な職務経験とAWS運用・監視経験を持ち、未知の領域でもAIや整理力を使って学習を進められるタイプ。音響や音楽制作の経験から、細部への感覚や継続的な創作力も強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:859",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "要点整理力",
+      "aliases": [],
+      "evidence": "多様な職務経験とAWS運用・監視経験を持ち、未知の領域でもAIや整理力を使って学習を進められるタイプ。音響や音楽制作の経験から、細部への感覚や継続的な創作力も強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:860",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "音楽・音響への感性と集中力",
+      "aliases": [
+        "音楽",
+        "音響への感性と集中力"
+      ],
+      "evidence": "多様な職務経験とAWS運用・監視経験を持ち、未知の領域でもAIや整理力を使って学習を進められるタイプ。音響や音楽制作の経験から、細部への感覚や継続的な創作力も強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:work_style:861",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "分からないことをそのままにせず、AIへの壁打ちを通じて考えを整理し、自分の中で要点化するスタイル。経験の幅を活かして、異なる業務や領域にも柔軟に適応する。",
+      "aliases": [
+        "分からないことをそのままにせず",
+        "aiへの壁打ちを通じて考えを整理し",
+        "自分の中で要点化するスタイル",
+        "経験の幅を活かして",
+        "異なる業務や領域にも柔軟に適応する",
+        "ai"
+      ],
+      "evidence": "多様な職務経験とAWS運用・監視経験を持ち、未知の領域でもAIや整理力を使って学習を進められるタイプ。音響や音楽制作の経験から、細部への感覚や継続的な創作力も強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:work_topic:862",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AWS運用・監視",
+      "aliases": [
+        "aws運用",
+        "監視",
+        "aws"
+      ],
+      "evidence": "多様な職務経験とAWS運用・監視経験を持ち、未知の領域でもAIや整理力を使って学習を進められるタイプ。音響や音楽制作の経験から、細部への感覚や継続的な創作力も強みです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:work_topic:863",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "AIを使った学習",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "多様な職務経験とAWS運用・監視経験を持ち、未知の領域でもAIや整理力を使って学習を進められるタイプ。音響や音楽制作の経験から、細部への感覚や継続的な創作力も強みです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:864",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AWS運用・監視",
+      "aliases": [
+        "aws運用",
+        "監視",
+        "aws"
+      ],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:865",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "AIを使った学習",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:866",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "要点整理",
+      "aliases": [],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:867",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "音楽",
+      "aliases": [],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:868",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "楽器演奏",
+      "aliases": [],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:869",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "歌声合成",
+      "aliases": [],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:870",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "MIX",
+      "aliases": [
+        "mix"
+      ],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:871",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "映画",
+      "aliases": [],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:872",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ゲーム",
+      "aliases": [],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:873",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "自炊",
+      "aliases": [],
+      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:874",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "成長",
+      "aliases": [],
+      "evidence": "成長実感、学習、創作活動、MVVへの共感を大切にしています。新しい環境で早くキャッチアップし、楽しみながら自分の幅を広げることにモチベーションがあります。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:875",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "学習",
+      "aliases": [],
+      "evidence": "成長実感、学習、創作活動、MVVへの共感を大切にしています。新しい環境で早くキャッチアップし、楽しみながら自分の幅を広げることにモチベーションがあります。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:876",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "創作",
+      "aliases": [],
+      "evidence": "成長実感、学習、創作活動、MVVへの共感を大切にしています。新しい環境で早くキャッチアップし、楽しみながら自分の幅を広げることにモチベーションがあります。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:877",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "MVVへの共感",
+      "aliases": [
+        "mvv"
+      ],
+      "evidence": "成長実感、学習、創作活動、MVVへの共感を大切にしています。新しい環境で早くキャッチアップし、楽しみながら自分の幅を広げることにモチベーションがあります。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:878",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "柔軟な適応",
+      "aliases": [],
+      "evidence": "成長実感、学習、創作活動、MVVへの共感を大切にしています。新しい環境で早くキャッチアップし、楽しみながら自分の幅を広げることにモチベーションがあります。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:879",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "分からないことを理解できるようになること",
+      "aliases": [],
+      "evidence": "成長実感、学習、創作活動、MVVへの共感を大切にしています。新しい環境で早くキャッチアップし、楽しみながら自分の幅を広げることにモチベーションがあります。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:880",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "AIを使って考えを整理すること",
+      "aliases": [
+        "ai"
+      ],
+      "evidence": "成長実感、学習、創作活動、MVVへの共感を大切にしています。新しい環境で早くキャッチアップし、楽しみながら自分の幅を広げることにモチベーションがあります。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:881",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "音楽やMIXなど創作に没頭すること",
+      "aliases": [
+        "mix"
+      ],
+      "evidence": "成長実感、学習、創作活動、MVVへの共感を大切にしています。新しい環境で早くキャッチアップし、楽しみながら自分の幅を広げることにモチベーションがあります。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:882",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:真栄城則明",
+      "employeeName": "真栄城則明",
+      "slackIds": [
+        "U0AGC56822X"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "新しい環境で早く戦力化すること",
+      "aliases": [],
+      "evidence": "成長実感、学習、創作活動、MVVへの共感を大切にしています。新しい環境で早くキャッチアップし、楽しみながら自分の幅を広げることにモチベーションがあります。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:883",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "技術領域を横断する経験",
+      "aliases": [],
+      "evidence": "開発、インフラ、サービス、テスト、採用・営業、ゲーム開発、作曲まで横断的な経験を持つ越境型の人材。技術と運用、クリエイティブをつなげて考えられる柔軟性が強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:884",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "ゲーム開発・作曲による創造性",
+      "aliases": [
+        "ゲーム開発",
+        "作曲による創造性"
+      ],
+      "evidence": "開発、インフラ、サービス、テスト、採用・営業、ゲーム開発、作曲まで横断的な経験を持つ越境型の人材。技術と運用、クリエイティブをつなげて考えられる柔軟性が強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:885",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "オペレーションリーダー経験",
+      "aliases": [],
+      "evidence": "開発、インフラ、サービス、テスト、採用・営業、ゲーム開発、作曲まで横断的な経験を持つ越境型の人材。技術と運用、クリエイティブをつなげて考えられる柔軟性が強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:886",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "採用・営業も含む対人経験",
+      "aliases": [
+        "採用",
+        "営業も含む対人経験"
+      ],
+      "evidence": "開発、インフラ、サービス、テスト、採用・営業、ゲーム開発、作曲まで横断的な経験を持つ越境型の人材。技術と運用、クリエイティブをつなげて考えられる柔軟性が強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:887",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "strength",
+      "label": "自然体で柔軟な関係構築",
+      "aliases": [],
+      "evidence": "開発、インフラ、サービス、テスト、採用・営業、ゲーム開発、作曲まで横断的な経験を持つ越境型の人材。技術と運用、クリエイティブをつなげて考えられる柔軟性が強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.dominant_strengths"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_style:888",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_style",
+      "label": "先入観を持たず、自然体で状況に入り、複数領域の経験を組み合わせて対応するスタイル。明確な型にはめすぎず、小さな変化や違和感も楽しみながら進める傾向がある。",
+      "aliases": [
+        "先入観を持たず",
+        "自然体で状況に入り",
+        "複数領域の経験を組み合わせて対応するスタイル",
+        "明確な型にはめすぎず",
+        "小さな変化や違和感も楽しみながら進める傾向がある"
+      ],
+      "evidence": "開発、インフラ、サービス、テスト、採用・営業、ゲーム開発、作曲まで横断的な経験を持つ越境型の人材。技術と運用、クリエイティブをつなげて考えられる柔軟性が強みです。",
+      "messageQuotes": [],
+      "sourceField": "work_styles_and_strengths.problem_solving_style"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_topic:889",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "ゲーム開発",
+      "aliases": [],
+      "evidence": "開発、インフラ、サービス、テスト、採用・営業、ゲーム開発、作曲まで横断的な経験を持つ越境型の人材。技術と運用、クリエイティブをつなげて考えられる柔軟性が強みです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_topic:890",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "開発・インフラ・サービス・テスト",
+      "aliases": [
+        "開発",
+        "インフラ",
+        "サービス",
+        "テスト"
+      ],
+      "evidence": "開発、インフラ、サービス、テスト、採用・営業、ゲーム開発、作曲まで横断的な経験を持つ越境型の人材。技術と運用、クリエイティブをつなげて考えられる柔軟性が強みです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_topic:891",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "仕事・相談",
+      "category": "work_topic",
+      "label": "SES採用・営業",
+      "aliases": [
+        "ses採用",
+        "営業",
+        "ses"
+      ],
+      "evidence": "開発、インフラ、サービス、テスト、採用・営業、ゲーム開発、作曲まで横断的な経験を持つ越境型の人材。技術と運用、クリエイティブをつなげて考えられる柔軟性が強みです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:892",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "作曲",
+      "aliases": [],
+      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:893",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "ゲーム開発",
+      "aliases": [],
+      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:894",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "開発・インフラ・サービス・テスト",
+      "aliases": [
+        "開発",
+        "インフラ",
+        "サービス",
+        "テスト"
+      ],
+      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:895",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "SES採用・営業",
+      "aliases": [
+        "ses採用",
+        "営業",
+        "ses"
+      ],
+      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:896",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "音楽",
+      "aliases": [],
+      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:897",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "日常生活",
+      "aliases": [],
+      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:898",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "動物",
+      "aliases": [],
+      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:899",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "interest",
+      "label": "自然体のコミュニケーション",
+      "aliases": [],
+      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
+      "messageQuotes": [],
+      "sourceField": "current_state.recent_topics_of_interest"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:900",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "自然体",
+      "aliases": [],
+      "evidence": "自然体、柔軟性、創作性、日常を楽しく整えることを大切にしています。技術や仕事の経験だけでなく、音楽や動物、生活のリズムなど幅広い関心を持っています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:901",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "柔軟性",
+      "aliases": [],
+      "evidence": "自然体、柔軟性、創作性、日常を楽しく整えることを大切にしています。技術や仕事の経験だけでなく、音楽や動物、生活のリズムなど幅広い関心を持っています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:902",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "創造性",
+      "aliases": [],
+      "evidence": "自然体、柔軟性、創作性、日常を楽しく整えることを大切にしています。技術や仕事の経験だけでなく、音楽や動物、生活のリズムなど幅広い関心を持っています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:903",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "穏やかな関係構築",
+      "aliases": [],
+      "evidence": "自然体、柔軟性、創作性、日常を楽しく整えることを大切にしています。技術や仕事の経験だけでなく、音楽や動物、生活のリズムなど幅広い関心を持っています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:904",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "value",
+      "label": "日常を楽しむこと",
+      "aliases": [],
+      "evidence": "自然体、柔軟性、創作性、日常を楽しく整えることを大切にしています。技術や仕事の経験だけでなく、音楽や動物、生活のリズムなど幅広い関心を持っています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.core_values"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:905",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "先入観なく周囲と関われること",
+      "aliases": [],
+      "evidence": "自然体、柔軟性、創作性、日常を楽しく整えることを大切にしています。技術や仕事の経験だけでなく、音楽や動物、生活のリズムなど幅広い関心を持っています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:906",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "技術と創作の経験を活かせること",
+      "aliases": [],
+      "evidence": "自然体、柔軟性、創作性、日常を楽しく整えることを大切にしています。技術や仕事の経験だけでなく、音楽や動物、生活のリズムなど幅広い関心を持っています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:907",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "のんびり楽しく日常を整えること",
+      "aliases": [],
+      "evidence": "自然体、柔軟性、創作性、日常を楽しく整えることを大切にしています。技術や仕事の経験だけでなく、音楽や動物、生活のリズムなど幅広い関心を持っています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    },
+    {
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:908",
+      "@type": "saiteki:SearchFacet",
+      "person": "person:八木橋 雄一",
+      "employeeName": "八木橋 雄一",
+      "slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "uiCategory": "興味・人柄",
+      "category": "recent_topic",
+      "label": "音楽や動物など好きなものについて自然に話せること",
+      "aliases": [],
+      "evidence": "自然体、柔軟性、創作性、日常を楽しく整えることを大切にしています。技術や仕事の経験だけでなく、音楽や動物、生活のリズムなど幅広い関心を持っています。",
+      "messageQuotes": [],
+      "sourceField": "values_and_motivators.motivation_triggers"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要
- Cloudflare Workerが参照する `data/search-facets.jsonld` を生成して追加
- `employees.json` を原本に、908件の検索facetを生成
- Worker設定済みの `SEARCH_FACETS_URL` がmain上で404にならないようにする

## テスト
- `npm run build:search-facets`
  - 908 facets生成を確認
- `npm run test:people-finder`
  - people finder RAG search OK
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('data/search-facets.jsonld','utf8')); console.log(data['@graph'].length); console.log(data.generatedAt ? 'generatedAt ok' : 'generatedAt missing');"`
  - `908`
  - `generatedAt ok`
- `git diff --cached --check`

## ブランチ・PR戦略
- base: `main`（#69 merge後の `01b1606`）
- working branch: `codex/add-search-facets-data-20260527`
- scope: Worker起動に必要な生成済み検索facetファイルのみ
- PRサイズ: 生成JSONのため行数は大きいが、コード変更はなし
- split criteria: Slack同期workflowやR2/KV配置への移行は別PR

## 残リスク
- 現時点では `employees.json` のプロフィール情報由来のfacetです。Slackメッセージ由来の引用追加は、Slack同期workflow実行後に再生成されます
- `SEARCH_FACETS_URL` はpublic raw GitHub URLを参照しているため、private運用にする場合はWorker側で `SEARCH_FACETS_TOKEN` かR2/KV配置へ切り替える必要があります