### PR TITLE
Slack社員検索のカテゴリ判定と検索精度を改善

### DIFF
--- a/data/search-facets.jsonld
+++ b/data/search-facets.jsonld
@@ -10,7 +10,7 @@
     "messageQuotes": "saiteki:messageQuotes",
     "sourceField": "saiteki:sourceField"
   },
-  "generatedAt": "2026-05-27T04:06:18.548Z",
+  "generatedAt": "2026-05-27T04:21:37.778Z",
   "sourceFiles": [
     "data/employees.json",
     "data/slack-messages.jsonl"
@@ -500,170 +500,6 @@
       ],
       "uiCategory": "興味・人柄",
       "category": "interest",
-      "label": "AIエージェントの活用と役割分担に関するベストプラクティス",
-      "aliases": [
-        "ai"
-      ],
-      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:27",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:杉本光一",
-      "employeeName": "杉本光一",
-      "slackIds": [
-        "U09MGV3MU9H",
-        "U08KH52ELPR"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AI（Letter of T, カスタムチューニング）によるS級人材モデル構築と継続的な運用（ペアデータ、毎週更新）",
-      "aliases": [
-        "ai",
-        "letter",
-        "of",
-        "カスタムチューニング",
-        "によるs級人材モデル構築と継続的な運用",
-        "ペアデータ",
-        "毎週更新"
-      ],
-      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:28",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:杉本光一",
-      "employeeName": "杉本光一",
-      "slackIds": [
-        "U09MGV3MU9H",
-        "U08KH52ELPR"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "Saiteki AI Standardの策定と公開、およびAI活用の本質的な哲学",
-      "aliases": [
-        "saiteki",
-        "ai",
-        "standardの策定と公開",
-        "およびai活用の本質的な哲学",
-        "standard"
-      ],
-      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:29",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:杉本光一",
-      "employeeName": "杉本光一",
-      "slackIds": [
-        "U09MGV3MU9H",
-        "U08KH52ELPR"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AI駆動開発と、それに伴うエンジニアの役割の変化",
-      "aliases": [
-        "ai駆動開発と",
-        "それに伴うエンジニアの役割の変化",
-        "ai"
-      ],
-      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:30",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:杉本光一",
-      "employeeName": "杉本光一",
-      "slackIds": [
-        "U09MGV3MU9H",
-        "U08KH52ELPR"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AIと法務に関する知見の習得",
-      "aliases": [
-        "ai"
-      ],
-      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:31",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:杉本光一",
-      "employeeName": "杉本光一",
-      "slackIds": [
-        "U09MGV3MU9H",
-        "U08KH52ELPR"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AI活用ドキュメントの運用とチームの知識共有促進",
-      "aliases": [
-        "ai"
-      ],
-      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:32",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:杉本光一",
-      "employeeName": "杉本光一",
-      "slackIds": [
-        "U09MGV3MU9H",
-        "U08KH52ELPR"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "ナレッジベースのカテゴリ設計とRAGを活用した具体的な情報検索の仕組み",
-      "aliases": [
-        "rag"
-      ],
-      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:33",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:杉本光一",
-      "employeeName": "杉本光一",
-      "slackIds": [
-        "U09MGV3MU9H",
-        "U08KH52ELPR"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "Neo4jなどのグラフデータベースを活用した検索ソリューションの検討",
-      "aliases": [
-        "neo4j"
-      ],
-      "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:34",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:杉本光一",
-      "employeeName": "杉本光一",
-      "slackIds": [
-        "U09MGV3MU9H",
-        "U08KH52ELPR"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
       "label": "新入社員の歓迎と社内交流",
       "aliases": [],
       "evidence": "全社的なAI活用ガイドライン『Saiteki AI Standard』を通じてAI時代の組織変革をリードしつつ、直近ではAIエージェントの具体的な活用や、Letter of Tを用いたS級人材モデル構築の可能性を探るなど、最先端AI技術の実践的な応用に取り組んでいる。社内コミュニケーションにおいては、新入社員の歓迎やカジュアルな交流にも積極的に参加し、組織…",
@@ -671,7 +507,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:35",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:interest:27",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -688,7 +524,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:36",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:28",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -711,7 +547,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:37",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:29",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -734,7 +570,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:38",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:30",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -751,7 +587,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:39",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:31",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -770,7 +606,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:40",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:32",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -791,7 +627,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:41",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:33",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -808,7 +644,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:42",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:34",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -825,7 +661,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:43",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:35",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -845,7 +681,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:44",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:36",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -862,7 +698,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:45",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:37",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -881,7 +717,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:46",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:38",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -902,7 +738,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:47",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:39",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -919,7 +755,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:48",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:40",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -936,7 +772,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:49",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:41",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -953,7 +789,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:50",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:42",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -970,7 +806,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:51",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:43",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -987,7 +823,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:52",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:value:44",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1004,7 +840,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:53",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:45",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1023,7 +859,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:54",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:46",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1043,7 +879,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:55",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:47",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1060,7 +896,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:56",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:48",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1077,7 +913,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:57",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:49",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1097,7 +933,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:58",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:50",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1117,7 +953,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:59",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:51",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1137,7 +973,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:60",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:52",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1154,7 +990,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:61",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:53",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1175,7 +1011,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:62",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:54",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1194,7 +1030,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:63",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:55",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1214,7 +1050,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:64",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:56",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1235,7 +1071,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:65",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:57",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1252,7 +1088,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:66",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:58",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1269,7 +1105,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:67",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:59",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1289,7 +1125,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:68",
+      "@id": "facet:%E6%9D%89%E6%9C%AC%E5%85%89%E4%B8%80:recent_topic:60",
       "@type": "saiteki:SearchFacet",
       "person": "person:杉本光一",
       "employeeName": "杉本光一",
@@ -1308,7 +1144,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:69",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:61",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1328,7 +1164,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:70",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:62",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1345,7 +1181,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:71",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:63",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1362,7 +1198,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:72",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:strength:64",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1379,7 +1215,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:work_style:73",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:work_style:65",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1401,7 +1237,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:work_topic:74",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:work_topic:66",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1420,7 +1256,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:work_topic:75",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:work_topic:67",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1439,26 +1275,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:76",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:青木淳一郎",
-      "employeeName": "青木淳一郎",
-      "slackIds": [
-        "U09NHL5HMRN",
-        "U09881886F7"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "Saitekiメンバーの入社経緯",
-      "aliases": [
-        "saiteki"
-      ],
-      "evidence": "年末年始を通してSaitekiメンバーとの出会いに深く感謝し、2026年を「飛躍の年」と意気込んでいる。12月上旬には業務負荷が高い様子が伺えたが、それを乗り越え、現在は非常に前向きな精神状態にある。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:77",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:68",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1475,7 +1292,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:78",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:69",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1495,26 +1312,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:interest:79",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:青木淳一郎",
-      "employeeName": "青木淳一郎",
-      "slackIds": [
-        "U09NHL5HMRN",
-        "U09881886F7"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "BIツールの知識習得",
-      "aliases": [
-        "bi"
-      ],
-      "evidence": "年末年始を通してSaitekiメンバーとの出会いに深く感謝し、2026年を「飛躍の年」と意気込んでいる。12月上旬には業務負荷が高い様子が伺えたが、それを乗り越え、現在は非常に前向きな精神状態にある。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:80",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:70",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1531,7 +1329,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:81",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:71",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1548,7 +1346,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:82",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:72",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1565,7 +1363,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:83",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:value:73",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1582,7 +1380,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:84",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:74",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1599,7 +1397,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:85",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:75",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1616,7 +1414,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:86",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:76",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1633,7 +1431,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:87",
+      "@id": "facet:%E9%9D%92%E6%9C%A8%E6%B7%B3%E4%B8%80%E9%83%8E:recent_topic:77",
       "@type": "saiteki:SearchFacet",
       "person": "person:青木淳一郎",
       "employeeName": "青木淳一郎",
@@ -1650,7 +1448,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:88",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:78",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1669,7 +1467,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:89",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:79",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1685,7 +1483,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:90",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:80",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1701,7 +1499,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:91",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:81",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1717,7 +1515,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:92",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:82",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1733,7 +1531,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:93",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:83",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1749,7 +1547,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:94",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:84",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1765,7 +1563,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:95",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:85",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1781,7 +1579,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:96",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:86",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1797,7 +1595,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:97",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:strength:87",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1813,7 +1611,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:work_style:98",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:work_style:88",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1836,7 +1634,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:99",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:89",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1852,7 +1650,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:100",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:90",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1872,7 +1670,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:101",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:91",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1888,7 +1686,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:102",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:92",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1904,7 +1702,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:103",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:interest:93",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1920,7 +1718,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:104",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:94",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1936,7 +1734,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:105",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:95",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1952,7 +1750,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:106",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:96",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1968,7 +1766,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:107",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:97",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -1984,7 +1782,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:108",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:98",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2000,7 +1798,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:109",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:99",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2016,7 +1814,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:110",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:100",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2032,7 +1830,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:111",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:101",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2048,7 +1846,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:112",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:value:102",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2064,7 +1862,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:113",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:103",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2080,7 +1878,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:114",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:104",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2096,7 +1894,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:115",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:105",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2112,7 +1910,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:116",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:106",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2128,7 +1926,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:117",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:107",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2144,7 +1942,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:118",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:108",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2160,7 +1958,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:119",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:109",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2176,7 +1974,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:120",
+      "@id": "facet:%E5%B0%8F%E6%9E%97%E7%BF%94:recent_topic:110",
       "@type": "saiteki:SearchFacet",
       "person": "person:小林翔",
       "employeeName": "小林翔",
@@ -2192,7 +1990,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:strength:121",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:strength:111",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2208,7 +2006,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:strength:122",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:strength:112",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2224,7 +2022,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:strength:123",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:strength:113",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2240,7 +2038,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_style:124",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_style:114",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2259,7 +2057,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_topic:125",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_topic:115",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2275,7 +2073,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_topic:126",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_topic:116",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2291,7 +2089,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_topic:127",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:work_topic:117",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2309,39 +2107,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:interest:128",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:櫻井志保",
-      "employeeName": "櫻井志保",
-      "slackIds": [
-        "U09S5RCV6GK"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "データ分析",
-      "aliases": [],
-      "evidence": "1月からの入社を控えており、新しい環境に対する高い期待感と意欲に満ち溢れています。自身のスキルを活かしつつ、さらなる専門性向上とチームへの貢献を目指しています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:interest:129",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:櫻井志保",
-      "employeeName": "櫻井志保",
-      "slackIds": [
-        "U09S5RCV6GK"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "データベース構築",
-      "aliases": [],
-      "evidence": "1月からの入社を控えており、新しい環境に対する高い期待感と意欲に満ち溢れています。自身のスキルを活かしつつ、さらなる専門性向上とチームへの貢献を目指しています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:interest:130",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:interest:118",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2357,25 +2123,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:interest:131",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:櫻井志保",
-      "employeeName": "櫻井志保",
-      "slackIds": [
-        "U09S5RCV6GK"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "Slackを通じたコミュニケーション",
-      "aliases": [
-        "slack"
-      ],
-      "evidence": "1月からの入社を控えており、新しい環境に対する高い期待感と意欲に満ち溢れています。自身のスキルを活かしつつ、さらなる専門性向上とチームへの貢献を目指しています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:132",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:119",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2391,7 +2139,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:133",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:120",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2407,7 +2155,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:134",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:121",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2423,7 +2171,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:135",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:value:122",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2439,7 +2187,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:136",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:123",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2455,7 +2203,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:137",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:124",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2471,7 +2219,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:138",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:125",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2487,7 +2235,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:139",
+      "@id": "facet:%E6%AB%BB%E4%BA%95%E5%BF%97%E4%BF%9D:recent_topic:126",
       "@type": "saiteki:SearchFacet",
       "person": "person:櫻井志保",
       "employeeName": "櫻井志保",
@@ -2503,7 +2251,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:140",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:127",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2524,7 +2272,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:141",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:128",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2544,7 +2292,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:142",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:129",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2566,7 +2314,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:143",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:130",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2583,7 +2331,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:144",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:131",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2604,7 +2352,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:145",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:132",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2621,7 +2369,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:146",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:133",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2638,7 +2386,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:147",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:134",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2658,7 +2406,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:148",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:135",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2675,7 +2423,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:149",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:136",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2692,7 +2440,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:150",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:137",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2709,7 +2457,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:151",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:138",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2726,7 +2474,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:152",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:139",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2743,7 +2491,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:153",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:140",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2762,7 +2510,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:154",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:141",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2783,7 +2531,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:155",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:142",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2803,7 +2551,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:156",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:143",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2822,7 +2570,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:157",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:144",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2839,7 +2587,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:158",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:145",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2858,7 +2606,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:159",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:146",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2875,7 +2623,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:160",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:147",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2894,7 +2642,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:161",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:strength:148",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2914,7 +2662,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:work_style:162",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:work_style:149",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2940,7 +2688,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:work_topic:163",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:work_topic:150",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2959,26 +2707,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:interest:164",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:田浦裕樹",
-      "employeeName": "田浦裕樹",
-      "slackIds": [
-        "U09MM9KS06S",
-        "U09822KG6DT"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "Saitekiのビジョンと業界課題の解決",
-      "aliases": [
-        "saiteki"
-      ],
-      "evidence": "同僚が執筆したnoteの内容に深く感動し、Saitekiのビジョン実現と業界課題解決への自身のコミットメントを再確認している。新しいメンバーの参加を心から歓迎し、彼が組織に合うことを見抜いていたことを伝え、今後のプロジェクトでの協業を楽しみにする、非常にポジティブな状態にある。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:interest:165",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:interest:151",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -2995,7 +2724,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:166",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:152",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3012,7 +2741,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:167",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:153",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3034,7 +2763,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:168",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:154",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3054,7 +2783,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:169",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:155",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3071,7 +2800,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:170",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:156",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3088,7 +2817,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:171",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:157",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3105,7 +2834,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:172",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:158",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3122,7 +2851,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:173",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:159",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3142,7 +2871,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:174",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:160",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3159,7 +2888,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:175",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:161",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3176,7 +2905,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:176",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:162",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3193,7 +2922,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:177",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:163",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3210,7 +2939,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:178",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:164",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3227,7 +2956,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:179",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:165",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3246,7 +2975,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:180",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:166",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3263,7 +2992,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:181",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:167",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3280,7 +3009,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:182",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:168",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3297,7 +3026,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:183",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:169",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3314,7 +3043,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:184",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:170",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3331,7 +3060,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:185",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:value:171",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3350,7 +3079,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:186",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:172",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3367,7 +3096,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:187",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:173",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3384,7 +3113,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:188",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:174",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3407,7 +3136,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:189",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:175",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3427,7 +3156,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:190",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:176",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3447,7 +3176,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:191",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:177",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3466,7 +3195,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:192",
+      "@id": "facet:%E7%94%B0%E6%B5%A6%E8%A3%95%E6%A8%B9:recent_topic:178",
       "@type": "saiteki:SearchFacet",
       "person": "person:田浦裕樹",
       "employeeName": "田浦裕樹",
@@ -3483,7 +3212,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:193",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:179",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3502,7 +3231,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:194",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:180",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3521,7 +3250,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:195",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:181",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3538,7 +3267,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:196",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:182",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3557,7 +3286,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:197",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:183",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3574,7 +3303,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:198",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:strength:184",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3591,7 +3320,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_style:199",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_style:185",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3617,7 +3346,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:200",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:186",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3637,7 +3366,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:201",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:187",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3656,7 +3385,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:202",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:188",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3673,7 +3402,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:203",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:189",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3690,7 +3419,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:204",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:work_topic:190",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3709,99 +3438,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:205",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:開米 敦則",
-      "employeeName": "開米 敦則",
-      "slackIds": [
-        "U09UHG24VUZ",
-        "U0A69LWD1QF"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "QAにおけるAI協働作業の定義と実践",
-      "aliases": [
-        "qa",
-        "ai"
-      ],
-      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:206",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:開米 敦則",
-      "employeeName": "開米 敦則",
-      "slackIds": [
-        "U09UHG24VUZ",
-        "U0A69LWD1QF"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "人とAIの役割分担と成果物の作成",
-      "aliases": [
-        "ai"
-      ],
-      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:207",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:開米 敦則",
-      "employeeName": "開米 敦則",
-      "slackIds": [
-        "U09UHG24VUZ",
-        "U0A69LWD1QF"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "テスト計画フェーズの最適化",
-      "aliases": [],
-      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:208",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:開米 敦則",
-      "employeeName": "開米 敦則",
-      "slackIds": [
-        "U09UHG24VUZ",
-        "U0A69LWD1QF"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "汎用テスト観点の修正と改善",
-      "aliases": [],
-      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:interest:209",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:開米 敦則",
-      "employeeName": "開米 敦則",
-      "slackIds": [
-        "U09UHG24VUZ",
-        "U0A69LWD1QF"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "Notion等を用いた情報共有とドキュメンテーション",
-      "aliases": [
-        "notion"
-      ],
-      "evidence": "現在、QAにおけるAI協働作業の概念化と初期段階の成果物作成に取り組んでいる。特にテスト計画フェーズの最適化と汎用テスト観点の修正に注力し、業務プロセスの戦略的な改善を進めている段階。関係者との情報共有と意見交換にも積極的。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:210",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:191",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3818,7 +3455,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:211",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:192",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3835,7 +3472,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:212",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:193",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3852,7 +3489,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:213",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:194",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3869,7 +3506,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:214",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:195",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3886,7 +3523,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:215",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:value:196",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3903,7 +3540,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:216",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:197",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3924,7 +3561,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:217",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:198",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3941,7 +3578,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:218",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:199",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3958,7 +3595,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:219",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:200",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3975,7 +3612,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:220",
+      "@id": "facet:%E9%96%8B%E7%B1%B3%20%E6%95%A6%E5%89%87:recent_topic:201",
       "@type": "saiteki:SearchFacet",
       "person": "person:開米 敦則",
       "employeeName": "開米 敦則",
@@ -3995,7 +3632,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:221",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:202",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4015,7 +3652,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:222",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:203",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4031,7 +3668,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:223",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:204",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4047,7 +3684,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:224",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:205",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4066,7 +3703,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:225",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:206",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4085,7 +3722,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:226",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:207",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4104,7 +3741,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:227",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:208",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4120,7 +3757,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:228",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:209",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4136,7 +3773,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:229",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:210",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4155,7 +3792,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:230",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:211",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4171,7 +3808,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:231",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:212",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4187,7 +3824,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:232",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:213",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4203,7 +3840,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:233",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:214",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4219,7 +3856,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:234",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:215",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4235,7 +3872,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:235",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:216",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4251,7 +3888,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:236",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:217",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4267,7 +3904,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:237",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:218",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4285,7 +3922,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:238",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:219",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4305,7 +3942,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:239",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:220",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4321,7 +3958,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:240",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:221",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4337,7 +3974,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:241",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:strength:222",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4356,7 +3993,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_style:242",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_style:223",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4380,7 +4017,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:243",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:224",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4396,7 +4033,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:244",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:225",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4418,7 +4055,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:245",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:226",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4438,7 +4075,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:246",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:227",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4458,7 +4095,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:247",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:228",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4478,7 +4115,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:248",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:229",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4496,7 +4133,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:249",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:230",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4512,7 +4149,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:250",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:work_topic:231",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4528,7 +4165,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:251",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:232",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4547,7 +4184,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:252",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:233",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4563,7 +4200,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:253",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:234",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4579,7 +4216,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:254",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:235",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4595,23 +4232,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:255",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:貴志雪乃",
-      "employeeName": "貴志雪乃",
-      "slackIds": [
-        "U0A0QFEQGRX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "リファラル採用の推進",
-      "aliases": [],
-      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:256",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:236",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4627,7 +4248,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:257",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:237",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4643,7 +4264,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:258",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:238",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4659,7 +4280,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:259",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:239",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4675,7 +4296,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:260",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:240",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4691,7 +4312,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:261",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:241",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4711,7 +4332,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:262",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:242",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4730,7 +4351,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:263",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:243",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4749,7 +4370,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:264",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:244",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4767,7 +4388,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:265",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:245",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4783,7 +4404,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:266",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:246",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4801,89 +4422,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:267",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:貴志雪乃",
-      "employeeName": "貴志雪乃",
-      "slackIds": [
-        "U0A0QFEQGRX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AI駆動開発 (AI-driven development)",
-      "aliases": [
-        "ai駆動開発",
-        "ai-driven",
-        "development",
-        "ai",
-        "driven"
-      ],
-      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:268",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:貴志雪乃",
-      "employeeName": "貴志雪乃",
-      "slackIds": [
-        "U0A0QFEQGRX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "Claude Code / Cursor",
-      "aliases": [
-        "claude",
-        "code",
-        "cursor"
-      ],
-      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:269",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:貴志雪乃",
-      "employeeName": "貴志雪乃",
-      "slackIds": [
-        "U0A0QFEQGRX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "MCP・AIエージェント活用",
-      "aliases": [
-        "mcp",
-        "aiエージェント活用",
-        "ai"
-      ],
-      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:270",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:貴志雪乃",
-      "employeeName": "貴志雪乃",
-      "slackIds": [
-        "U0A0QFEQGRX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "SDD × AI駆動開発フロー",
-      "aliases": [
-        "sdd",
-        "ai駆動開発フロー",
-        "ai"
-      ],
-      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:271",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:247",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4899,25 +4438,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:272",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:貴志雪乃",
-      "employeeName": "貴志雪乃",
-      "slackIds": [
-        "U0A0QFEQGRX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AWSアーキテクチャ設計",
-      "aliases": [
-        "aws"
-      ],
-      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:273",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:248",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4933,23 +4454,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:274",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:貴志雪乃",
-      "employeeName": "貴志雪乃",
-      "slackIds": [
-        "U0A0QFEQGRX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "技術的理想と事業的理想の合意形成",
-      "aliases": [],
-      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:275",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:249",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4965,23 +4470,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:276",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:貴志雪乃",
-      "employeeName": "貴志雪乃",
-      "slackIds": [
-        "U0A0QFEQGRX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "技術的負債と事業成長のバランス",
-      "aliases": [],
-      "evidence": "直近のログでは、社のYouTubeチャンネルを通じた外部への情報発信に加え、社内勉強会アーカイブの共有を通じて社員への高度な技術的知見（AWSアーキテクチャ設計、プロジェクトマネジメント、合意形成術など）の提供に注力している。DX戦略やアナログ・トランスフォーメーション (AX)、AI駆動開発といった先進的なテーマに関心が高く、これらの情報を構造的かつ魅力…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:277",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:interest:250",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -4997,7 +4486,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:278",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:251",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5013,7 +4502,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:279",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:252",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5029,7 +4518,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:280",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:253",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5045,7 +4534,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:281",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:254",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5061,7 +4550,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:282",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:255",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5077,7 +4566,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:283",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:256",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5093,7 +4582,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:284",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:257",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5109,7 +4598,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:285",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:258",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5125,7 +4614,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:286",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:259",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5141,7 +4630,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:287",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:260",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5157,7 +4646,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:288",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:261",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5173,7 +4662,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:289",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:262",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5189,7 +4678,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:290",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:263",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5205,7 +4694,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:291",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:264",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5221,7 +4710,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:292",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:265",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5237,7 +4726,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:293",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:266",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5253,7 +4742,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:294",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:267",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5269,7 +4758,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:295",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:268",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5285,7 +4774,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:296",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:269",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5301,7 +4790,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:297",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:270",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5319,7 +4808,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:298",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:271",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5337,7 +4826,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:299",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:272",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5353,7 +4842,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:300",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:273",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5369,7 +4858,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:301",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:value:274",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5385,7 +4874,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:302",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:275",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5401,7 +4890,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:303",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:276",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5417,7 +4906,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:304",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:277",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5433,7 +4922,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:305",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:278",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5449,7 +4938,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:306",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:279",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5465,7 +4954,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:307",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:280",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5481,7 +4970,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:308",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:281",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5500,7 +4989,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:309",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:282",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5516,7 +5005,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:310",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:283",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5535,7 +5024,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:311",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:284",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5551,7 +5040,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:312",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:285",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5570,7 +5059,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:313",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:286",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5589,7 +5078,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:314",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:287",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5608,7 +5097,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:315",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:288",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5624,7 +5113,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:316",
+      "@id": "facet:%E8%B2%B4%E5%BF%97%E9%9B%AA%E4%B9%83:recent_topic:289",
       "@type": "saiteki:SearchFacet",
       "person": "person:貴志雪乃",
       "employeeName": "貴志雪乃",
@@ -5643,7 +5132,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:317",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:290",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5660,7 +5149,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:318",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:291",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5677,7 +5166,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:319",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:292",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5694,7 +5183,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:320",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:293",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5711,7 +5200,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:321",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:294",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5728,7 +5217,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:322",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:295",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5745,7 +5234,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:323",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:296",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5762,7 +5251,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:324",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:297",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5779,7 +5268,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:325",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:298",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5796,7 +5285,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:326",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:299",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5813,7 +5302,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:327",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:300",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5830,7 +5319,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:328",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:301",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5847,7 +5336,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:329",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:302",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5864,7 +5353,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:330",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:strength:303",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5881,7 +5370,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:work_style:331",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:work_style:304",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5907,7 +5396,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:332",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:305",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5924,7 +5413,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:333",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:306",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5941,7 +5430,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:334",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:307",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5958,7 +5447,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:335",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:308",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5978,7 +5467,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:336",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:309",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -5999,7 +5488,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:337",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:310",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6016,7 +5505,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:338",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:interest:311",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6033,7 +5522,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:339",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:312",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6050,7 +5539,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:340",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:313",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6067,7 +5556,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:341",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:314",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6084,7 +5573,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:342",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:315",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6101,7 +5590,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:343",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:316",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6118,7 +5607,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:344",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:317",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6135,7 +5624,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:345",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:318",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6152,7 +5641,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:346",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:319",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6169,7 +5658,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:347",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:320",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6186,7 +5675,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:348",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:value:321",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6203,7 +5692,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:349",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:322",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6223,7 +5712,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:350",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:323",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6240,7 +5729,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:351",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:324",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6257,7 +5746,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:352",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:325",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6277,7 +5766,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:353",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:326",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6297,7 +5786,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:354",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:327",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6317,7 +5806,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:355",
+      "@id": "facet:%E4%B8%8A%E9%81%BC%E5%A4%AA%E9%83%8E:recent_topic:328",
       "@type": "saiteki:SearchFacet",
       "person": "person:上遼太郎",
       "employeeName": "上遼太郎",
@@ -6334,7 +5823,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:356",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:329",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6351,7 +5840,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:357",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:330",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6368,7 +5857,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:358",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:331",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6385,7 +5874,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:359",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:332",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6402,7 +5891,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:360",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:333",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6419,7 +5908,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:361",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:334",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6436,7 +5925,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:362",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:335",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6453,7 +5942,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:363",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:336",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6470,7 +5959,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:364",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:337",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6487,7 +5976,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:365",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:338",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6504,7 +5993,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:366",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:339",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6521,7 +6010,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:367",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:340",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6538,7 +6027,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:368",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:341",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6555,7 +6044,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:369",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:342",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6572,7 +6061,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:370",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:343",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6589,7 +6078,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:371",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:344",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6606,7 +6095,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:372",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:345",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6623,7 +6112,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:373",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:346",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6640,7 +6129,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:374",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:347",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6657,7 +6146,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:375",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:348",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6674,7 +6163,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:376",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:349",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6691,7 +6180,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:377",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:350",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6708,7 +6197,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:378",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:351",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6725,7 +6214,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:379",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:352",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6742,7 +6231,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:380",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:353",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6759,7 +6248,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:381",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:354",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6776,7 +6265,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:382",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:355",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6793,7 +6282,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:383",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:356",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6810,7 +6299,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:384",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:357",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6827,7 +6316,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:385",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:358",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6847,7 +6336,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:386",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:359",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6864,7 +6353,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:387",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:360",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6881,7 +6370,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:388",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:361",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6898,7 +6387,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:389",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:362",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6915,7 +6404,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:390",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:363",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6934,7 +6423,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:391",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:364",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6951,7 +6440,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:392",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:365",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6968,7 +6457,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:393",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:366",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -6985,7 +6474,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:394",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:367",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7002,7 +6491,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:395",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:368",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7019,7 +6508,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:396",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:369",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7036,7 +6525,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:397",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:370",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7053,7 +6542,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:398",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:371",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7070,7 +6559,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:399",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:372",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7087,7 +6576,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:400",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:373",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7104,7 +6593,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:401",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:374",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7121,7 +6610,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:402",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:375",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7138,7 +6627,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:403",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:376",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7155,7 +6644,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:404",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:377",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7172,7 +6661,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:405",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:378",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7189,7 +6678,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:406",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:379",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7206,7 +6695,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:407",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:380",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7223,7 +6712,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:408",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:381",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7240,7 +6729,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:409",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:382",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7257,7 +6746,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:410",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:383",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7274,7 +6763,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:411",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:384",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7291,7 +6780,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:412",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:385",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7308,7 +6797,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:413",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:386",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7325,7 +6814,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:414",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:387",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7342,7 +6831,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:415",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:388",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7359,7 +6848,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:416",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:strength:389",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7376,7 +6865,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_style:417",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_style:390",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7402,7 +6891,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_topic:418",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_topic:391",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7419,7 +6908,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_topic:419",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_topic:392",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7439,7 +6928,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_topic:420",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:work_topic:393",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7458,7 +6947,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:421",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:394",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7478,24 +6967,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:422",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:小松田真伍",
-      "employeeName": "小松田真伍",
-      "slackIds": [
-        "U0A7VHB07J4",
-        "U0AAUUU1LTX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "インフラ自動化の最適判断と実装戦略",
-      "aliases": [],
-      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:423",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:395",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7512,46 +6984,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:424",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:小松田真伍",
-      "employeeName": "小松田真伍",
-      "slackIds": [
-        "U0A7VHB07J4",
-        "U0AAUUU1LTX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "ビジネス戦略と技術的判断の融合（特に上位レイヤーの思考）",
-      "aliases": [
-        "ビジネス戦略と技術的判断の融合",
-        "特に上位レイヤーの思考"
-      ],
-      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:425",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:小松田真伍",
-      "employeeName": "小松田真伍",
-      "slackIds": [
-        "U0A7VHB07J4",
-        "U0AAUUU1LTX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AIを活用した情報翻訳と伝達の重要性",
-      "aliases": [
-        "ai"
-      ],
-      "evidence": "自身の業務改善や知見を深めるために勉強会へ積極的に参加し、アーキテクチャの合意形成、自動化、コスト最適化といった実践的なインフラ技術とビジネス戦略の融合について集中的に学習している。自身の知見を組織に還元しようとする高い意欲が伺え、現在のSESとしての経験を活かしつつ、より上位のレイヤーでの貢献を目指している。特に、ビジネスにおけるエンジニアの役割拡大に強…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:426",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:396",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7570,7 +7003,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:427",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:interest:397",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7590,7 +7023,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:428",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:398",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7607,7 +7040,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:429",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:399",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7624,7 +7057,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:430",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:400",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7641,7 +7074,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:431",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:401",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7658,7 +7091,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:432",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:402",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7675,7 +7108,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:433",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:403",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7692,7 +7125,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:434",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:404",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7709,7 +7142,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:435",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:405",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7726,7 +7159,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:436",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:406",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7743,7 +7176,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:437",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:407",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7760,7 +7193,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:438",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:408",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7777,7 +7210,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:439",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:409",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7794,7 +7227,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:440",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:410",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7811,7 +7244,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:441",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:411",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7828,7 +7261,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:442",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:412",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7845,7 +7278,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:443",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:413",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7862,7 +7295,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:444",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:414",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7879,7 +7312,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:445",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:415",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7896,7 +7329,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:446",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:416",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7913,7 +7346,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:447",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:417",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7930,7 +7363,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:448",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:418",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7947,7 +7380,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:449",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:419",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7964,7 +7397,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:450",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:420",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -7983,7 +7416,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:451",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:421",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8000,7 +7433,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:452",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:422",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8017,7 +7450,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:453",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:423",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8034,7 +7467,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:454",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:424",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8051,7 +7484,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:455",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:425",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8068,7 +7501,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:456",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:426",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8085,7 +7518,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:457",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:427",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8102,7 +7535,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:458",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:428",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8119,7 +7552,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:459",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:429",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8136,7 +7569,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:460",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:430",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8153,7 +7586,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:461",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:431",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8170,7 +7603,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:462",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:432",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8187,7 +7620,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:463",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:433",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8204,7 +7637,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:464",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:434",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8221,7 +7654,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:465",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:435",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8241,7 +7674,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:466",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:436",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8258,7 +7691,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:467",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:value:437",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8275,7 +7708,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:468",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:438",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8292,7 +7725,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:469",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:439",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8309,7 +7742,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:470",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:440",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8326,7 +7759,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:471",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:441",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8343,7 +7776,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:472",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:442",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8360,7 +7793,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:473",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:443",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8377,7 +7810,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:474",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:444",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8394,7 +7827,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:475",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:445",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8411,7 +7844,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:476",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:446",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8428,7 +7861,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:477",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:447",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8445,7 +7878,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:478",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:448",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8462,7 +7895,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:479",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:449",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8479,7 +7912,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:480",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:450",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8496,7 +7929,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:481",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:451",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8513,7 +7946,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:482",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:452",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8530,7 +7963,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:483",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:453",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8547,7 +7980,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:484",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:454",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8564,7 +7997,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:485",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:455",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8581,7 +8014,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:486",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:456",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8600,7 +8033,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:487",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:457",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8617,7 +8050,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:488",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:458",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8634,7 +8067,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:489",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:459",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8651,7 +8084,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:490",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:460",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8668,7 +8101,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:491",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:461",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8685,7 +8118,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:492",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:462",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8702,7 +8135,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:493",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:463",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8719,7 +8152,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:494",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:464",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8736,7 +8169,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:495",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:465",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8753,7 +8186,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:496",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:466",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8770,7 +8203,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:497",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:467",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8787,7 +8220,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:498",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:468",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8804,7 +8237,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:499",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:469",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8821,7 +8254,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:500",
+      "@id": "facet:%E5%B0%8F%E6%9D%BE%E7%94%B0%E7%9C%9F%E4%BC%8D:recent_topic:470",
       "@type": "saiteki:SearchFacet",
       "person": "person:小松田真伍",
       "employeeName": "小松田真伍",
@@ -8838,7 +8271,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:501",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:471",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8854,7 +8287,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:502",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:472",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8870,7 +8303,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:503",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:473",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8886,7 +8319,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:504",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:474",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8902,7 +8335,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:505",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:475",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8918,7 +8351,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:506",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:476",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8934,7 +8367,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:507",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:477",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8950,7 +8383,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:508",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:478",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8966,7 +8399,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:509",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:479",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8982,7 +8415,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:510",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:480",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -8998,7 +8431,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:511",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:481",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9014,7 +8447,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:512",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:482",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9030,7 +8463,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:513",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:strength:483",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9046,7 +8479,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:work_style:514",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:work_style:484",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9071,7 +8504,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:515",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:485",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9087,7 +8520,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:516",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:486",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9103,7 +8536,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:517",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:487",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9119,7 +8552,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:518",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:488",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9137,7 +8570,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:519",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:489",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9157,7 +8590,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:520",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:490",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9177,7 +8610,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:521",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:491",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9193,7 +8626,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:522",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:492",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9213,7 +8646,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:523",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:493",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9229,7 +8662,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:524",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:494",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9245,7 +8678,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:525",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:495",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9265,7 +8698,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:526",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:496",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9281,7 +8714,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:527",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:497",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9297,7 +8730,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:528",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:498",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9313,7 +8746,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:529",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:499",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9331,7 +8764,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:530",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:interest:500",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9350,7 +8783,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:531",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:501",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9366,7 +8799,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:532",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:502",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9382,7 +8815,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:533",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:503",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9398,7 +8831,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:534",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:504",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9414,7 +8847,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:535",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:505",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9430,7 +8863,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:536",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:506",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9446,7 +8879,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:537",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:507",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9462,7 +8895,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:538",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:508",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9478,7 +8911,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:539",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:509",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9494,7 +8927,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:540",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:value:510",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9510,7 +8943,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:541",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:511",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9526,7 +8959,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:542",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:512",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9542,7 +8975,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:543",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:513",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9558,7 +8991,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:544",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:514",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9574,7 +9007,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:545",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:515",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9590,7 +9023,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:546",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:516",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9606,7 +9039,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:547",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:517",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9622,7 +9055,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:548",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:518",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9638,7 +9071,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:549",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:519",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9654,7 +9087,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:550",
+      "@id": "facet:%E5%B0%8F%E5%B3%B6%E9%81%BC%E7%A5%90:recent_topic:520",
       "@type": "saiteki:SearchFacet",
       "person": "person:小島遼祐",
       "employeeName": "小島遼祐",
@@ -9670,7 +9103,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:551",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:521",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9686,7 +9119,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:552",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:522",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9702,7 +9135,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:553",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:523",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9718,7 +9151,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:554",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:524",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9734,7 +9167,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:555",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:525",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9750,7 +9183,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:556",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:526",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9766,7 +9199,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:557",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:527",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9782,7 +9215,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:558",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:528",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9798,7 +9231,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:559",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:529",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9814,7 +9247,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:560",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:530",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9830,7 +9263,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:561",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:531",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9846,7 +9279,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:562",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:532",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9862,7 +9295,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:563",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:533",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9878,7 +9311,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:564",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:534",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9894,7 +9327,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:565",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:535",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9910,7 +9343,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:566",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:536",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9926,7 +9359,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:567",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:537",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9942,7 +9375,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:568",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:538",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9958,7 +9391,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:569",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:strength:539",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9974,7 +9407,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:work_style:570",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:work_style:540",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -9998,7 +9431,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:571",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:541",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10014,7 +9447,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:572",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:542",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10030,7 +9463,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:573",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:543",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10049,7 +9482,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:574",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:544",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10065,7 +9498,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:575",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:interest:545",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10081,7 +9514,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:576",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:546",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10097,7 +9530,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:577",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:547",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10113,7 +9546,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:578",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:548",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10129,7 +9562,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:579",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:549",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10145,7 +9578,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:580",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:550",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10161,7 +9594,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:581",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:551",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10177,7 +9610,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:582",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:552",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10193,7 +9626,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:583",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:553",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10209,7 +9642,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:584",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:554",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10225,7 +9658,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:585",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:555",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10241,7 +9674,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:586",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:556",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10257,7 +9690,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:587",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:557",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10273,7 +9706,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:588",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:558",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10289,7 +9722,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:589",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:559",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10305,7 +9738,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:590",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:560",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10321,7 +9754,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:591",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:561",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10337,7 +9770,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:592",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:562",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10353,7 +9786,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:593",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:563",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10369,7 +9802,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:594",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:564",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10385,7 +9818,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:595",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:565",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10401,7 +9834,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:596",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:566",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10417,7 +9850,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:597",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:567",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10433,7 +9866,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:598",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:568",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10449,7 +9882,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:599",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:value:569",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10465,7 +9898,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:600",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:570",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10481,7 +9914,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:601",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:571",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10497,7 +9930,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:602",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:572",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10513,7 +9946,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:603",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:573",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10532,7 +9965,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:604",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:574",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10548,7 +9981,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:605",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:575",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10564,7 +9997,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:606",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:576",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10580,7 +10013,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:607",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:577",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10596,7 +10029,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:608",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:578",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10612,7 +10045,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:609",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:579",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10628,7 +10061,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:610",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:580",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10644,7 +10077,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:611",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:581",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10660,7 +10093,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:612",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:582",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10676,7 +10109,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:613",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:583",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10692,7 +10125,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:614",
+      "@id": "facet:%E8%97%A4%E4%BA%95%E8%8A%99%E7%BE%8E%E5%AD%90:recent_topic:584",
       "@type": "saiteki:SearchFacet",
       "person": "person:藤井芙美子",
       "employeeName": "藤井芙美子",
@@ -10708,7 +10141,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:615",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:585",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10729,7 +10162,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:616",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:586",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10745,7 +10178,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:617",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:587",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10763,7 +10196,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:618",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:588",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10779,7 +10212,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:619",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:589",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10795,7 +10228,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:620",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:strength:590",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10811,7 +10244,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:work_style:621",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:work_style:591",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10836,7 +10269,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:work_topic:622",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:work_topic:592",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10858,29 +10291,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:623",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:菅野聖也",
-      "employeeName": "菅野聖也",
-      "slackIds": [
-        "U0ADE4H3RTJ"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AI技術の活用（旅行計画、献立作成、コード生成）",
-      "aliases": [
-        "ai技術の活用",
-        "旅行計画",
-        "献立作成",
-        "コード生成",
-        "ai"
-      ],
-      "evidence": "入社直後で、開発者としての復帰とチームとの協働に非常に前向きである。AI技術への関心は非常に高く、読書を通じて多様な知識を吸収し、それを業務やコミュニケーションに活かそうとしている。人との交流も積極的に楽しみ、新しい環境での活躍を強く望んでいる。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:624",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:593",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10901,7 +10312,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:625",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:594",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10917,7 +10328,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:626",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:595",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10933,7 +10344,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:627",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:interest:596",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10949,7 +10360,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:628",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:597",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10965,7 +10376,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:629",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:598",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10981,7 +10392,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:630",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:599",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -10997,7 +10408,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:631",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:600",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -11015,7 +10426,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:632",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:value:601",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -11034,7 +10445,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:633",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:602",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -11050,7 +10461,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:634",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:603",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -11066,7 +10477,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:635",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:604",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -11084,7 +10495,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:636",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:605",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -11100,7 +10511,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:637",
+      "@id": "facet:%E8%8F%85%E9%87%8E%E8%81%96%E4%B9%9F:recent_topic:606",
       "@type": "saiteki:SearchFacet",
       "person": "person:菅野聖也",
       "employeeName": "菅野聖也",
@@ -11119,7 +10530,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:638",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:607",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11135,7 +10546,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:639",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:608",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11153,7 +10564,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:640",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:609",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11169,7 +10580,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:641",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:610",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11185,7 +10596,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:642",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:611",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11201,7 +10612,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:643",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:612",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11217,7 +10628,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:644",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:strength:613",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11233,7 +10644,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_style:645",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_style:614",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11258,7 +10669,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:646",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:615",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11279,7 +10690,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:647",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:616",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11304,7 +10715,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:648",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:617",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11322,7 +10733,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:649",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:618",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11338,7 +10749,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:650",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:work_topic:619",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11356,87 +10767,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:651",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:佐藤傑",
-      "employeeName": "佐藤傑",
-      "slackIds": [
-        "U09MKUXAU4V"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "小型高性能AIモデルの動向と実用性（DeepSeek4を含む）",
-      "aliases": [
-        "小型高性能aiモデルの動向と実用性",
-        "deepseek4を含む",
-        "ai",
-        "deepseek4"
-      ],
-      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:652",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:佐藤傑",
-      "employeeName": "佐藤傑",
-      "slackIds": [
-        "U09MKUXAU4V"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "Mac環境でのAI活用（M4 Max、GPTsoss、Mac Studioでの動作可能性）",
-      "aliases": [
-        "mac環境でのai活用",
-        "m4",
-        "max",
-        "gptsoss",
-        "mac",
-        "studioでの動作可能性",
-        "ai",
-        "studio"
-      ],
-      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:653",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:佐藤傑",
-      "employeeName": "佐藤傑",
-      "slackIds": [
-        "U09MKUXAU4V"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "海外AIスタートアップとの連携",
-      "aliases": [
-        "ai"
-      ],
-      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:654",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:佐藤傑",
-      "employeeName": "佐藤傑",
-      "slackIds": [
-        "U09MKUXAU4V"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "国際的なチーム開発",
-      "aliases": [],
-      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:655",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:620",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11452,25 +10783,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:interest:656",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:佐藤傑",
-      "employeeName": "佐藤傑",
-      "slackIds": [
-        "U09MKUXAU4V"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "コスト効率の良いAIソリューション",
-      "aliases": [
-        "ai"
-      ],
-      "evidence": "海外での活動を継続しており、現在はUAEに滞在し、その後ASEAN中台韓を巡り、来年には帰国予定。国際的なチーム開発やハッカソンに積極的に参加し、最新のAI技術（特に小型高性能AIモデルのMac環境での実用性）に高い関心を持ち、M4 MaxでのGPTsossの動作を検証・共有するなど、その情報共有を通じて実践的な活用を模索している。質問歓迎の姿勢で、コミュ…",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:657",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:621",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11486,7 +10799,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:658",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:622",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11502,7 +10815,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:659",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:623",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11518,7 +10831,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:660",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:624",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11534,7 +10847,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:661",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:625",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11550,7 +10863,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:662",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:626",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11566,7 +10879,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:663",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:value:627",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11582,7 +10895,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:664",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:628",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11598,7 +10911,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:665",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:629",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11614,7 +10927,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:666",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:630",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11630,7 +10943,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:667",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:631",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11646,7 +10959,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:668",
+      "@id": "facet:%E4%BD%90%E8%97%A4%E5%82%91:recent_topic:632",
       "@type": "saiteki:SearchFacet",
       "person": "person:佐藤傑",
       "employeeName": "佐藤傑",
@@ -11662,7 +10975,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:669",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:633",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11679,7 +10992,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:670",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:634",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11696,7 +11009,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:671",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:635",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11713,7 +11026,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:672",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:636",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11730,7 +11043,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:673",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:637",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11747,7 +11060,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:674",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:638",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11764,7 +11077,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:675",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:639",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11781,7 +11094,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:676",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:640",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11798,7 +11111,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:677",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:strength:641",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11819,7 +11132,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:work_style:678",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:work_style:642",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11845,7 +11158,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:work_topic:679",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:work_topic:643",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11864,7 +11177,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:interest:680",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:interest:644",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11887,7 +11200,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:interest:681",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:interest:645",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11909,26 +11222,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:interest:682",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:鈴木悠斗",
-      "employeeName": "鈴木悠斗",
-      "slackIds": [
-        "U09MPBUHTEE",
-        "U08SCMU6544"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AIを活用した情報収集や知識共有",
-      "aliases": [
-        "ai"
-      ],
-      "evidence": "家族との時間を積極的に楽しみ、その喜びやエピソード（GWの過ごし方、けん玉チャレンジ）をチームと共有する。社内では積極的にコミュニケーションを取り、他者の話にも共感を示す。また、AIを情報収集に活用するなど、新しいツールへの適応力と貢献意欲も高い。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:683",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:646",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11945,7 +11239,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:684",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:647",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11962,7 +11256,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:685",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:648",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11979,7 +11273,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:686",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:649",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -11996,7 +11290,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:687",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:650",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12013,7 +11307,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:688",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:651",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12030,7 +11324,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:689",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:652",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12047,7 +11341,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:690",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:653",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12064,7 +11358,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:691",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:654",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12081,7 +11375,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:692",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:655",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12098,7 +11392,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:693",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:656",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12115,7 +11409,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:694",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:value:657",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12132,7 +11426,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:695",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:658",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12152,7 +11446,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:696",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:659",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12173,7 +11467,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:697",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:660",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12193,7 +11487,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:698",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:661",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12210,7 +11504,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:699",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:662",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12227,7 +11521,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:700",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:663",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12244,7 +11538,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:701",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:664",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12264,7 +11558,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:702",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:665",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12281,7 +11575,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:703",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:666",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12301,7 +11595,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:704",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:667",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12318,7 +11612,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:705",
+      "@id": "facet:%E9%88%B4%E6%9C%A8%E6%82%A0%E6%96%97:recent_topic:668",
       "@type": "saiteki:SearchFacet",
       "person": "person:鈴木悠斗",
       "employeeName": "鈴木悠斗",
@@ -12335,7 +11629,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:706",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:669",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12352,7 +11646,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:707",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:670",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12369,7 +11663,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:708",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:671",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12386,7 +11680,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:709",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:672",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12403,7 +11697,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:710",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:673",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12420,7 +11714,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:711",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:674",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12437,7 +11731,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:712",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:675",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12454,7 +11748,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:713",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:676",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12471,7 +11765,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:714",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:677",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12488,7 +11782,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:715",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:678",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12505,7 +11799,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:716",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:679",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12522,7 +11816,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:717",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:680",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12539,7 +11833,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:718",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:681",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12556,7 +11850,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:719",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:682",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12573,7 +11867,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:720",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:683",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12590,7 +11884,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:721",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:684",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12609,7 +11903,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:722",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:685",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12626,7 +11920,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:723",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:686",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12643,7 +11937,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:724",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:687",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12663,7 +11957,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:725",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:688",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12680,7 +11974,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:726",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:689",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12697,7 +11991,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:727",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:690",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12714,7 +12008,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:728",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:691",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12731,7 +12025,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:729",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:692",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12748,7 +12042,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:730",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:693",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12765,7 +12059,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:731",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:694",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12782,7 +12076,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:732",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:695",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12799,7 +12093,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:733",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:696",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12816,7 +12110,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:734",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:697",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12833,7 +12127,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:735",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:strength:698",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12850,7 +12144,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_style:736",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_style:699",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12876,7 +12170,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:737",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:700",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12896,7 +12190,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:738",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:701",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12917,7 +12211,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:739",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:702",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12942,7 +12236,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:740",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:work_topic:703",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12962,7 +12256,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:741",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:704",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -12985,27 +12279,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:742",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:戸塚直道",
-      "employeeName": "戸塚直道",
-      "slackIds": [
-        "U09MGUVJ8BV",
-        "U07288UDABX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "新しく参画した営業部長・人事部長の活躍と幹部への権限委譲",
-      "aliases": [
-        "新しく参画した営業部長",
-        "人事部長の活躍と幹部への権限委譲"
-      ],
-      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:743",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:705",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13027,28 +12301,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:744",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:戸塚直道",
-      "employeeName": "戸塚直道",
-      "slackIds": [
-        "U09MGUVJ8BV",
-        "U07288UDABX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "内定率10%という厳選採用と社風・カルチャーとのマッチ度重視",
-      "aliases": [
-        "内定率10%という厳選採用と社風",
-        "カルチャーとのマッチ度重視",
-        "10"
-      ],
-      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:745",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:706",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13065,52 +12318,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:746",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:戸塚直道",
-      "employeeName": "戸塚直道",
-      "slackIds": [
-        "U09MGUVJ8BV",
-        "U07288UDABX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "上場SIer社長から学んだAI戦略、営業ハック、プロの「準備」、ホスピタリティ",
-      "aliases": [
-        "上場sier社長から学んだai戦略",
-        "営業ハック",
-        "プロの",
-        "準備",
-        "ホスピタリティ",
-        "sier",
-        "ai"
-      ],
-      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:747",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:戸塚直道",
-      "employeeName": "戸塚直道",
-      "slackIds": [
-        "U09MGUVJ8BV",
-        "U07288UDABX"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "「準備が9割」という自身の営業哲学と戦略的交渉術",
-      "aliases": [
-        "準備が9割",
-        "という自身の営業哲学と戦略的交渉術"
-      ],
-      "evidence": "組織が急速に拡大し、正社員35名（業務委託含め55名）規模に到達。厳選採用でカルチャーを維持しつつ、幹部への権限委譲により自身の役割をM&A戦略推進や高難易度案件獲得といったトップ戦略にシフト。社内イベントも活発に開催し、自身の学びと哲学を「Letter of T」で精力的に共有。会社の成長を牽引する強いコミットメントと健全な危機感を持つ。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:748",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:707",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13127,7 +12335,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:749",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:interest:708",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13144,7 +12352,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:750",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:709",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13163,7 +12371,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:751",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:710",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13180,7 +12388,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:752",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:711",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13199,7 +12407,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:753",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:712",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13218,7 +12426,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:754",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:713",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13235,7 +12443,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:755",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:714",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13252,7 +12460,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:756",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:715",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13269,7 +12477,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:757",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:716",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13286,7 +12494,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:758",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:717",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13303,7 +12511,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:759",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:718",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13320,7 +12528,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:760",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:719",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13337,7 +12545,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:761",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:720",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13354,7 +12562,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:762",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:721",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13371,7 +12579,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:763",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:722",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13388,7 +12596,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:764",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:723",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13405,7 +12613,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:765",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:724",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13426,7 +12634,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:766",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:725",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13443,7 +12651,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:767",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:726",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13460,7 +12668,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:768",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:727",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13477,7 +12685,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:769",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:728",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13494,7 +12702,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:770",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:729",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13511,7 +12719,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:771",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:730",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13528,7 +12736,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:772",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:731",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13545,7 +12753,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:773",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:732",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13562,7 +12770,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:774",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:733",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13579,7 +12787,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:775",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:734",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13596,7 +12804,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:776",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:735",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13613,7 +12821,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:777",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:value:736",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13630,7 +12838,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:778",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:737",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13651,7 +12859,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:779",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:738",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13673,7 +12881,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:780",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:739",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13695,7 +12903,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:781",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:740",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13717,7 +12925,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:782",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:741",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13737,7 +12945,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:783",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:742",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13758,7 +12966,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:784",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:743",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13780,7 +12988,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:785",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:744",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13800,7 +13008,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:786",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:745",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13821,7 +13029,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:787",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:746",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13841,7 +13049,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:788",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:747",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13858,7 +13066,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:789",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:748",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13875,7 +13083,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:790",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:749",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13898,7 +13106,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:791",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:750",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13920,7 +13128,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:792",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:751",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13942,7 +13150,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:793",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:752",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13965,7 +13173,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:794",
+      "@id": "facet:%E6%88%B8%E5%A1%9A%E7%9B%B4%E9%81%93:recent_topic:753",
       "@type": "saiteki:SearchFacet",
       "person": "person:戸塚直道",
       "employeeName": "戸塚直道",
@@ -13985,7 +13193,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:795",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:754",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14001,7 +13209,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:796",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:755",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14017,7 +13225,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:797",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:756",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14033,7 +13241,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:798",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:757",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14049,7 +13257,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:799",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:758",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14065,7 +13273,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:800",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:strength:759",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14081,7 +13289,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:work_style:801",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:work_style:760",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14105,7 +13313,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:802",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:761",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14121,7 +13329,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:803",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:762",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14137,7 +13345,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:804",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:763",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14153,7 +13361,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:805",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:764",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14169,7 +13377,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:806",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:765",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14185,7 +13393,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:807",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:766",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14201,7 +13409,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:808",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:767",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14217,7 +13425,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:809",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:768",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14233,7 +13441,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:810",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:769",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14249,7 +13457,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:811",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:770",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14265,7 +13473,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:812",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:interest:771",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14281,7 +13489,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:813",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:772",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14297,7 +13505,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:814",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:773",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14313,7 +13521,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:815",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:774",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14329,7 +13537,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:816",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:775",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14345,7 +13553,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:817",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:776",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14361,7 +13569,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:818",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:value:777",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14377,7 +13585,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:819",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:778",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14393,7 +13601,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:820",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:779",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14409,7 +13617,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:821",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:780",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14425,7 +13633,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:822",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:781",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14441,7 +13649,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:823",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:782",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14457,7 +13665,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:824",
+      "@id": "facet:%E6%A6%8E%E6%9C%AC%E8%A9%A9%E7%B9%94:recent_topic:783",
       "@type": "saiteki:SearchFacet",
       "person": "person:榎本詩織",
       "employeeName": "榎本詩織",
@@ -14476,7 +13684,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:825",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:784",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14495,7 +13703,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:826",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:785",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14514,7 +13722,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:827",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:786",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14530,7 +13738,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:828",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:787",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14546,7 +13754,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:829",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:strength:788",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14562,7 +13770,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_style:830",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_style:789",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14583,7 +13791,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:831",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:790",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14599,7 +13807,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:832",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:791",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14615,7 +13823,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:833",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:792",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14631,7 +13839,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:834",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:793",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14647,7 +13855,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:835",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:work_topic:794",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14665,55 +13873,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:836",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:上原基臣",
-      "employeeName": "上原基臣",
-      "slackIds": [
-        "U0AFQUQ1H9R"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "サーバ運用",
-      "aliases": [],
-      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:837",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:上原基臣",
-      "employeeName": "上原基臣",
-      "slackIds": [
-        "U0AFQUQ1H9R"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "テスト業務",
-      "aliases": [],
-      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:838",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:上原基臣",
-      "employeeName": "上原基臣",
-      "slackIds": [
-        "U0AFQUQ1H9R"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "改修開発",
-      "aliases": [],
-      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:839",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:795",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14729,23 +13889,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:840",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:上原基臣",
-      "employeeName": "上原基臣",
-      "slackIds": [
-        "U0AFQUQ1H9R"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "総合テスト",
-      "aliases": [],
-      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:841",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:796",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14761,7 +13905,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:842",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:797",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14777,7 +13921,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:843",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:798",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14793,7 +13937,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:844",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:799",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14809,7 +13953,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:845",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:800",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14825,25 +13969,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:interest:846",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:上原基臣",
-      "employeeName": "上原基臣",
-      "slackIds": [
-        "U0AFQUQ1H9R"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "Slackコミュニケーション",
-      "aliases": [
-        "slack"
-      ],
-      "evidence": "入社前後の新しい環境に向けて、技術面と社内コミュニケーションの両方でキャッチアップしようとしている状態です。自己認識は現実的で、周囲との交流を通じて早くなじもうとしています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:847",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:801",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14859,7 +13985,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:848",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:802",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14875,7 +14001,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:849",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:803",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14891,7 +14017,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:850",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:804",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14907,7 +14033,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:851",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:value:805",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14923,7 +14049,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:852",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:806",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14939,7 +14065,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:853",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:807",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14955,7 +14081,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:854",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:808",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14973,7 +14099,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:855",
+      "@id": "facet:%E4%B8%8A%E5%8E%9F%E5%9F%BA%E8%87%A3:recent_topic:809",
       "@type": "saiteki:SearchFacet",
       "person": "person:上原基臣",
       "employeeName": "上原基臣",
@@ -14994,7 +14120,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:856",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:810",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15014,7 +14140,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:857",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:811",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15030,7 +14156,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:858",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:812",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15048,7 +14174,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:859",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:813",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15064,7 +14190,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:860",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:strength:814",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15083,7 +14209,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:work_style:861",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:work_style:815",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15106,7 +14232,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:work_topic:862",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:work_topic:816",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15126,7 +14252,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:work_topic:863",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:work_topic:817",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15144,45 +14270,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:864",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:真栄城則明",
-      "employeeName": "真栄城則明",
-      "slackIds": [
-        "U0AGC56822X"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AWS運用・監視",
-      "aliases": [
-        "aws運用",
-        "監視",
-        "aws"
-      ],
-      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:865",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:真栄城則明",
-      "employeeName": "真栄城則明",
-      "slackIds": [
-        "U0AGC56822X"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "AIを使った学習",
-      "aliases": [
-        "ai"
-      ],
-      "evidence": "入社前後のキャッチアップ段階で、IT領域の学習を継続しながら早く貢献しようとしている状態です。AI活用や音楽制作など、自分なりの学習・創作習慣も持っています。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:866",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:818",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15198,7 +14286,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:867",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:819",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15214,7 +14302,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:868",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:820",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15230,7 +14318,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:869",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:821",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15246,7 +14334,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:870",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:822",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15264,7 +14352,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:871",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:823",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15280,7 +14368,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:872",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:824",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15296,7 +14384,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:873",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:interest:825",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15312,7 +14400,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:874",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:826",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15328,7 +14416,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:875",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:827",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15344,7 +14432,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:876",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:828",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15360,7 +14448,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:877",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:829",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15378,7 +14466,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:878",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:value:830",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15394,7 +14482,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:879",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:831",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15410,7 +14498,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:880",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:832",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15428,7 +14516,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:881",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:833",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15446,7 +14534,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:882",
+      "@id": "facet:%E7%9C%9F%E6%A0%84%E5%9F%8E%E5%89%87%E6%98%8E:recent_topic:834",
       "@type": "saiteki:SearchFacet",
       "person": "person:真栄城則明",
       "employeeName": "真栄城則明",
@@ -15462,7 +14550,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:883",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:835",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15478,7 +14566,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:884",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:836",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15497,7 +14585,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:885",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:837",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15513,7 +14601,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:886",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:838",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15532,7 +14620,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:887",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:strength:839",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15548,7 +14636,7 @@
       "sourceField": "work_styles_and_strengths.dominant_strengths"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_style:888",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_style:840",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15570,7 +14658,7 @@
       "sourceField": "work_styles_and_strengths.problem_solving_style"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_topic:889",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_topic:841",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15586,7 +14674,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_topic:890",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_topic:842",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15607,7 +14695,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_topic:891",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:work_topic:843",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15627,7 +14715,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:892",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:844",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15643,64 +14731,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:893",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:八木橋 雄一",
-      "employeeName": "八木橋 雄一",
-      "slackIds": [
-        "U0AG0UR6LDA"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "ゲーム開発",
-      "aliases": [],
-      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:894",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:八木橋 雄一",
-      "employeeName": "八木橋 雄一",
-      "slackIds": [
-        "U0AG0UR6LDA"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "開発・インフラ・サービス・テスト",
-      "aliases": [
-        "開発",
-        "インフラ",
-        "サービス",
-        "テスト"
-      ],
-      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:895",
-      "@type": "saiteki:SearchFacet",
-      "person": "person:八木橋 雄一",
-      "employeeName": "八木橋 雄一",
-      "slackIds": [
-        "U0AG0UR6LDA"
-      ],
-      "uiCategory": "興味・人柄",
-      "category": "interest",
-      "label": "SES採用・営業",
-      "aliases": [
-        "ses採用",
-        "営業",
-        "ses"
-      ],
-      "evidence": "入社前後の段階で、周囲と自然体で少しずつ関わろうとしている状態です。幅広い経験と独自の感性を持ち、技術面・創作面の両方で話題の接点を作れそうです。",
-      "messageQuotes": [],
-      "sourceField": "current_state.recent_topics_of_interest"
-    },
-    {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:896",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:845",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15716,7 +14747,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:897",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:846",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15732,7 +14763,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:898",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:847",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15748,7 +14779,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:899",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:interest:848",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15764,7 +14795,7 @@
       "sourceField": "current_state.recent_topics_of_interest"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:900",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:849",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15780,7 +14811,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:901",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:850",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15796,7 +14827,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:902",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:851",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15812,7 +14843,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:903",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:852",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15828,7 +14859,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:904",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:value:853",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15844,7 +14875,7 @@
       "sourceField": "values_and_motivators.core_values"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:905",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:854",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15860,7 +14891,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:906",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:855",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15876,7 +14907,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:907",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:856",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",
@@ -15892,7 +14923,7 @@
       "sourceField": "values_and_motivators.motivation_triggers"
     },
     {
-      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:908",
+      "@id": "facet:%E5%85%AB%E6%9C%A8%E6%A9%8B%20%E9%9B%84%E4%B8%80:recent_topic:857",
       "@type": "saiteki:SearchFacet",
       "person": "person:八木橋 雄一",
       "employeeName": "八木橋 雄一",

--- a/scripts/build-search-facets.js
+++ b/scripts/build-search-facets.js
@@ -45,7 +45,8 @@ const FIELD_CONFIGS = [
     category: 'interest',
     uiCategory: UI_CATEGORY_PERSONAL,
     path: 'current_state.recent_topics_of_interest',
-    evidencePath: 'current_state.summary'
+    evidencePath: 'current_state.summary',
+    filter: isPersonalTopic
   },
   {
     category: 'value',
@@ -94,6 +95,10 @@ function cleanText(value, maxLength = 180) {
 
 function isWorkTopic(value) {
   return /ai|aws|react|next|rag|qa|pm|poc|gemini|cursor|notion|slack|api|db|sql|bi|開発|運用|監視|設計|要件|技術|テスト|品質|分析|採用|営業|総務|人事|オンボーディング|データ|プロンプト|自動化|インフラ|サーバ/i.test(value);
+}
+
+function isPersonalTopic(value) {
+  return !isWorkTopic(value);
 }
 
 function normalizeText(value) {

--- a/scripts/people-finder-rag-search.js
+++ b/scripts/people-finder-rag-search.js
@@ -4,7 +4,10 @@ const path = require('path');
 const DEFAULT_FACETS_FILE = path.join(__dirname, '../data/search-facets.jsonld');
 const UI_CATEGORY_WORK = '仕事・相談';
 const UI_CATEGORY_PERSONAL = '興味・人柄';
-const DEFAULT_THRESHOLD = 0.16;
+const DEFAULT_THRESHOLD = 0.18;
+
+const WORK_QUERY_PATTERN = /aws|azure|gcp|react|next|rag|qa|pm|poc|api|db|sql|bi|gemini|cursor|notion|slack|github|開発|運用|監視|設計|要件|技術|テスト|品質|分析|採用|営業|総務|人事|オンボーディング|データ|プロンプト|自動化|インフラ|サーバ|アーキテクチャ|マネジメント|合意形成/i;
+const PERSONAL_QUERY_PATTERN = /好き|趣味|休日|映画|音楽|ゲーム|アニメ|漫画|マンガ|ポケモン|ガンダム|トミカ|自炊|料理|楽器|動物|犬|猫|旅行|スポーツ|読書/i;
 
 function normalizeText(value) {
   return String(value || '')
@@ -18,11 +21,30 @@ function normalizeText(value) {
 function stripQueryHelpers(query) {
   return normalizeText(query)
     .replace(/が好きな人|が好き|好きな人|好きな|興味がある人|詳しい人|得意な人|できる人|話せる人|相談できる人|相談したい|人/g, ' ')
+    .replace(/を知っている人|を知っている|知っている人|知っている|知ってる|分かる|わかる|経験者|または|もしくは|あるいは/g, ' ')
     .replace(/について|に関心がある|に興味がある|を探して|探して|教えて|詳しい|相談/g, ' ')
     .replace(/([a-z0-9+#.])([^a-z0-9+#.\s])/g, '$1 $2')
     .replace(/([^a-z0-9+#.\s])([a-z0-9+#.])/g, '$1 $2')
+    .replace(/(^|\s)(に|を|が|は|の|と|で)(?=\s|$)/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+function inferCategoryFromQuery(query) {
+  const value = normalizeText(query);
+  if (PERSONAL_QUERY_PATTERN.test(value)) return UI_CATEGORY_PERSONAL;
+  if (WORK_QUERY_PATTERN.test(value)) return UI_CATEGORY_WORK;
+  return null;
+}
+
+function resolveSearchCategory(query, selectedCategory) {
+  const normalizedCategory = normalizeCategory(selectedCategory || UI_CATEGORY_PERSONAL);
+  const inferredCategory = inferCategoryFromQuery(query);
+  return {
+    category: inferredCategory || normalizedCategory,
+    inferred: Boolean(inferredCategory && inferredCategory !== normalizedCategory),
+    selectedCategory: normalizedCategory
+  };
 }
 
 function normalizeCategory(category) {
@@ -163,8 +185,10 @@ function dedupeQuotes(quotes) {
 }
 
 function searchFacets(facets, query, options = {}) {
-  const uiCategory = normalizeCategory(options.category || UI_CATEGORY_PERSONAL);
-  const threshold = Number(options.threshold ?? DEFAULT_THRESHOLD);
+  const categoryResolution = resolveSearchCategory(query, options.category || UI_CATEGORY_PERSONAL);
+  const uiCategory = categoryResolution.category;
+  const parsedThreshold = Number(options.threshold ?? DEFAULT_THRESHOLD);
+  const threshold = Number.isFinite(parsedThreshold) ? parsedThreshold : DEFAULT_THRESHOLD;
   const queryText = stripQueryHelpers(query) || normalizeText(query);
   const queryVector = vectorize(queryText);
   const queryTerms = tokenize(queryText);
@@ -203,7 +227,8 @@ function main() {
       category: args.category,
       threshold: args.threshold
     });
-    console.log(JSON.stringify({ query, category: normalizeCategory(args.category || UI_CATEGORY_PERSONAL), results }, null, 2));
+    const categoryResolution = resolveSearchCategory(query, args.category || UI_CATEGORY_PERSONAL);
+    console.log(JSON.stringify({ query, category: categoryResolution.category, categoryInferred: categoryResolution.inferred, results }, null, 2));
   } catch (error) {
     console.error(error.message);
     process.exit(1);
@@ -219,6 +244,7 @@ module.exports = {
   loadFacets,
   normalizeCategory,
   normalizeText,
+  resolveSearchCategory,
   searchFacets,
   stripQueryHelpers,
   tokenize

--- a/scripts/test-people-finder-rag-search.js
+++ b/scripts/test-people-finder-rag-search.js
@@ -4,7 +4,7 @@ const os = require('os');
 const path = require('path');
 
 const { buildSearchFacets, writeSearchFacets } = require('./build-search-facets');
-const { searchFacets, stripQueryHelpers } = require('./people-finder-rag-search');
+const { resolveSearchCategory, searchFacets, stripQueryHelpers } = require('./people-finder-rag-search');
 
 const employees = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/employees.json'), 'utf8'));
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'people-finder-'));
@@ -25,6 +25,12 @@ const sampleMessages = [
 ];
 
 assert.strictEqual(stripQueryHelpers('ポケモンが好きな人'), 'ポケモン');
+assert.strictEqual(stripQueryHelpers('AWSに詳しい人、または経験者'), 'aws');
+assert.deepStrictEqual(resolveSearchCategory('AWSを知っている人', '興味・人柄'), {
+  category: '仕事・相談',
+  inferred: true,
+  selectedCategory: '興味・人柄'
+});
 
 const facets = buildSearchFacets(employees, sampleMessages);
 writeSearchFacets(facets, tempFacetsFile);
@@ -45,6 +51,11 @@ assert(pokemon.includes('榎本詩織'), '榎本詩織 should match pokemon');
 const aws = searchFacets(graph, 'AWS運用に詳しい人', { category: '仕事・相談', threshold: 0.16 })
   .map((result) => result.employeeName);
 assert(aws.includes('真栄城則明'), '真栄城則明 should match AWS operations');
+
+const inferredAws = searchFacets(graph, 'AWSに詳しい人、または経験者', { category: '興味・人柄' })
+  .map((result) => result.employeeName);
+assert(inferredAws.includes('真栄城則明'), 'AWS query should infer work category');
+assert(!inferredAws.includes('榎本詩織'), 'AWS query should not match broad personal experience facets');
 
 const gundam = searchFacets(graph, 'ガンダムが好きな人', { category: '興味・人柄', threshold: 0.16 });
 const uehara = gundam.find((result) => result.employeeName === '上原基臣');

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -6,7 +6,10 @@ const CATEGORY_ACTION = 'category';
 const QUERY_ACTION = 'query';
 const CATEGORY_BLOCK = 'search_category';
 const QUERY_BLOCK = 'search_query';
-const DEFAULT_THRESHOLD = 0.16;
+const DEFAULT_THRESHOLD = 0.18;
+
+const WORK_QUERY_PATTERN = /aws|azure|gcp|react|next|rag|qa|pm|poc|api|db|sql|bi|gemini|cursor|notion|slack|github|開発|運用|監視|設計|要件|技術|テスト|品質|分析|採用|営業|総務|人事|オンボーディング|データ|プロンプト|自動化|インフラ|サーバ|アーキテクチャ|マネジメント|合意形成/i;
+const PERSONAL_QUERY_PATTERN = /好き|趣味|休日|映画|音楽|ゲーム|アニメ|漫画|マンガ|ポケモン|ガンダム|トミカ|自炊|料理|楽器|動物|犬|猫|旅行|スポーツ|読書/i;
 
 const CATEGORY_OPTIONS = [
   {
@@ -70,13 +73,17 @@ async function handleSlashCommand(rawBody, env, ctx) {
   if (query.trim()) {
     ctx.waitUntil(openModal(env, triggerId, buildSearchModal({
       channelId,
-      initialQuery: query.trim()
+      initialQuery: query.trim(),
+      initialCategory: resolveSearchCategory(query.trim(), '仕事・相談').category
     })));
   }
 
   return slackJson({
     response_type: 'ephemeral',
-    blocks: buttonBlocks({ initialQuery: query.trim() })
+    blocks: buttonBlocks({
+      initialQuery: query.trim(),
+      initialCategory: resolveSearchCategory(query.trim(), '仕事・相談').category
+    })
   });
 }
 
@@ -91,7 +98,7 @@ async function handleInteraction(rawBody, env, ctx) {
       ctx.waitUntil(openModal(env, payload.trigger_id, buildSearchModal({
         channelId: payload.channel?.id,
         initialQuery: actionValue.initialQuery || '',
-        initialCategory: actionValue.initialCategory || '興味・人柄'
+        initialCategory: resolveSearchCategory(actionValue.initialQuery || '', actionValue.initialCategory || '仕事・相談').category
       })));
     }
     return new Response('', { status: 200 });
@@ -185,9 +192,10 @@ async function postSearchResults(env, { channel, user, query, category }) {
   if (!channel || !user) return;
 
   try {
+    const categoryResolution = resolveSearchCategory(query, category || '仕事・相談');
     const facets = await loadFacets(env);
     const results = searchFacets(facets, query, {
-      category,
+      category: categoryResolution.category,
       threshold: env.PEOPLE_FINDER_THRESHOLD || DEFAULT_THRESHOLD
     });
     const chunks = chunkResults(results);
@@ -200,7 +208,8 @@ async function postSearchResults(env, { channel, user, query, category }) {
         text: `「${query}」に近い社員検索結果`,
         blocks: resultMessageBlocks({
           query,
-          category,
+          category: categoryResolution.category,
+          categoryInferred: categoryResolution.inferred,
           results: pages[index],
           totalResults: results.length,
           page: index + 1,
@@ -271,7 +280,7 @@ async function loadFacets(env) {
   return cachedFacets;
 }
 
-function buildSearchModal({ channelId, initialQuery = '', initialCategory = '興味・人柄' }) {
+function buildSearchModal({ channelId, initialQuery = '', initialCategory = '仕事・相談' }) {
   const selectedCategory = normalizeCategory(initialCategory);
   const initialOption = CATEGORY_OPTIONS.find((item) => item.value === selectedCategory) || CATEGORY_OPTIONS[1];
   const queryElement = {
@@ -324,7 +333,7 @@ function buildSearchModal({ channelId, initialQuery = '', initialCategory = '興
   };
 }
 
-function buttonBlocks({ initialQuery = '', initialCategory = '興味・人柄' } = {}) {
+function buttonBlocks({ initialQuery = '', initialCategory = '仕事・相談' } = {}) {
   const text = initialQuery
     ? `「${escapeMrkdwn(initialQuery)}」で社員検索を開きます。`
     : '社員データから、相談できそうな人や話しかけるきっかけになる人を探します。';
@@ -345,14 +354,18 @@ function buttonBlocks({ initialQuery = '', initialCategory = '興味・人柄' }
   ];
 }
 
-function resultMessageBlocks({ query, category, results, totalResults, page, totalPages }) {
+function resultMessageBlocks({ query, category, categoryInferred = false, results, totalResults, page, totalPages }) {
+  const categoryText = categoryInferred
+    ? `${escapeMrkdwn(category)} (入力内容から自動判定)`
+    : escapeMrkdwn(category);
+
   if (results.length === 0) {
     return [
       {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `「${escapeMrkdwn(query)}」に合う社員は見つかりませんでした。\nカテゴリ: *${escapeMrkdwn(category)}*`
+          text: `「${escapeMrkdwn(query)}」に合う社員は見つかりませんでした。\nカテゴリ: *${categoryText}*`
         }
       }
     ];
@@ -363,7 +376,7 @@ function resultMessageBlocks({ query, category, results, totalResults, page, tot
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `「${escapeMrkdwn(query)}」に近い社員が *${totalResults}名* 見つかりました。\nカテゴリ: *${escapeMrkdwn(category)}* / 表示: ${page}/${totalPages}`
+        text: `「${escapeMrkdwn(query)}」に近い社員が *${totalResults}名* 見つかりました。\nカテゴリ: *${categoryText}* / 表示: ${page}/${totalPages}`
       }
     },
     { type: 'divider' }
@@ -404,7 +417,7 @@ function formatResult(result) {
 }
 
 function searchFacets(facets, query, options = {}) {
-  const uiCategory = normalizeCategory(options.category || '興味・人柄');
+  const uiCategory = resolveSearchCategory(query, options.category || '興味・人柄').category;
   const parsedThreshold = Number(options.threshold ?? DEFAULT_THRESHOLD);
   const threshold = Number.isFinite(parsedThreshold) ? parsedThreshold : DEFAULT_THRESHOLD;
   const queryText = stripQueryHelpers(query) || normalizeText(query);
@@ -486,12 +499,31 @@ function normalizeCategory(category) {
   return category;
 }
 
+function inferCategoryFromQuery(query) {
+  const value = normalizeText(query);
+  if (PERSONAL_QUERY_PATTERN.test(value)) return '興味・人柄';
+  if (WORK_QUERY_PATTERN.test(value)) return '仕事・相談';
+  return null;
+}
+
+function resolveSearchCategory(query, selectedCategory) {
+  const normalizedCategory = normalizeCategory(selectedCategory || '興味・人柄');
+  const inferredCategory = inferCategoryFromQuery(query);
+  return {
+    category: inferredCategory || normalizedCategory,
+    inferred: Boolean(inferredCategory && inferredCategory !== normalizedCategory),
+    selectedCategory: normalizedCategory
+  };
+}
+
 function stripQueryHelpers(query) {
   return normalizeText(query)
     .replace(/が好きな人|が好き|好きな人|好きな|興味がある人|詳しい人|得意な人|できる人|話せる人|相談できる人|相談したい|人/g, ' ')
+    .replace(/を知っている人|を知っている|知っている人|知っている|知ってる|分かる|わかる|経験者|または|もしくは|あるいは/g, ' ')
     .replace(/について|に関心がある|に興味がある|を探して|探して|教えて|詳しい|相談/g, ' ')
     .replace(/([a-z0-9+#.])([^a-z0-9+#.\s])/g, '$1 $2')
     .replace(/([^a-z0-9+#.\s])([a-z0-9+#.])/g, '$1 $2')
+    .replace(/(^|\s)(に|を|が|は|の|と|で)(?=\s|$)/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/workers/slack-people-finder/wrangler.jsonc
+++ b/workers/slack-people-finder/wrangler.jsonc
@@ -9,7 +9,7 @@
   },
   "vars": {
     "SLACK_CHANNEL_ID_3": "C0B6G5S8WUU",
-    "PEOPLE_FINDER_THRESHOLD": "0.16",
+    "PEOPLE_FINDER_THRESHOLD": "0.18",
     "SEARCH_FACETS_CACHE_SECONDS": "300",
     "SEARCH_FACETS_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/search-facets.jsonld"
   },


### PR DESCRIPTION
## 概要
- `AWSを知っている人` のような技術・業務系クエリを `仕事・相談` へ自動判定するようにした
- `ポケモンが好きな人` のような趣味系クエリは `興味・人柄` へ自動判定するようにした
- `知っている人` / `経験者` / `または` などの検索補助語を除去し、広すぎる「多様な経験」系facetが引っかかりにくくした
- `current_state.recent_topics_of_interest` のうち業務系topicは個人趣味カテゴリに出さないようにし、`search-facets.jsonld` を再生成した
- Workerの初期カテゴリと閾値を調整し、結果には自動判定されたカテゴリを表示する

## 確認結果
- `AWSを知っている人` + `興味・人柄` 指定でも `仕事・相談` に自動判定
  - 真栄城則明: `AWS運用・監視`
  - 貴志雪乃: `AWSアーキテクチャ設計`
  - 榎本詩織の `多様な経験` は出ない
- `AWS運用` は真栄城則明、上原基臣、小松田真伍に絞られる
- `ポケモンが好きな人` は引き続き `興味・人柄` で榎本詩織、小島遼祐、藤井芙美子が出る

## テスト
- `npm run build:search-facets`
  - 857 facets生成
- `npm run test:people-finder`
  - people finder RAG search OK
- `node --check workers/slack-people-finder/src/index.js`
- `git diff --check`
- `npx wrangler deploy --dry-run --config workers/slack-people-finder/wrangler.jsonc`
- `npx wrangler deploy --config workers/slack-people-finder/wrangler.jsonc`
  - Worker version: `607cae7f-8cac-426a-854b-97df7a9d0338`
- Slack入口投稿を `仕事・相談` 初期値のボタンに更新済み

## ブランチ・PR戦略
- base: `main`（#70 merge後の `3821a13`）
- working branch: `codex/improve-people-finder-quality-20260527`
- scope: Slack社員検索のカテゴリ判定、検索補助語除去、生成facetのカテゴリ整理に限定
- PRサイズ: 生成済み `search-facets.jsonld` の再生成差分が中心。コード変更は小さめ
- split criteria: ベクトルDB化、LLM rerank、Slackメッセージ同期の追加改善は別PR

## 残リスク
- まだRAG/類似検索は軽量なトークン類似で、LLM rerankやEmbedding検索ではない
- Slackメッセージ引用は `data/slack-messages.jsonl` が十分に蓄積されるまで少ない
- `AI` のように仕事/趣味の両方にあり得る語は、文脈語での判定を今後さらに増やす余地がある