### PR TITLE
Slack社員検索で抽出根拠の表示を改善

### DIFF
--- a/scripts/people-finder-rag-search.js
+++ b/scripts/people-finder-rag-search.js
@@ -156,6 +156,7 @@ function aggregateByEmployee(scoredFacets, threshold) {
       category: item.facet.category,
       label: item.facet.label,
       score: Number(item.score.toFixed(4)),
+      sourceField: item.facet.sourceField,
       evidence: item.facet.evidence
     });
     result.messageQuotes.push(...(item.facet.messageQuotes || []));

--- a/scripts/slack-people-finder-app.js
+++ b/scripts/slack-people-finder-app.js
@@ -163,9 +163,11 @@ function buttonBlocks({ initialQuery = '', initialCategory = '興味・人柄' }
 function formatResult(result) {
   const mention = result.slackIds?.[0] ? `<@${result.slackIds[0]}>` : escapeMrkdwn(result.employeeName);
   const reasons = result.reasons
-    .map((reason) => `・${escapeMrkdwn(reason.label)} (${Math.round(reason.score * 100)}%)`)
+    .map((reason) => `・${escapeMrkdwn(reason.label)} (${Math.round(reason.score * 100)}%) - ${escapeMrkdwn(reasonSourceLabel(reason))}`)
     .join('\n');
-  const evidence = result.reasons.find((reason) => reason.evidence)?.evidence;
+  const extractionEvidence = result.reasons
+    .map((reason) => `・「${escapeMrkdwn(reasonSourceLabel(reason))}」に「${escapeMrkdwn(truncate(reason.label, 80))}」が保存されています。`)
+    .join('\n');
   const quotes = result.messageQuotes
     .map((quote) => {
       const quoteText = `「${escapeMrkdwn(truncate(quote.text, 140))}」`;
@@ -180,11 +182,28 @@ function formatResult(result) {
       text: [
         `*${mention}*`,
         `選出理由:\n${reasons || '関連する検索facetが閾値を超えました。'}`,
-        evidence ? `根拠要約: ${escapeMrkdwn(truncate(evidence, 180))}` : '',
-        quotes ? `メッセージ引用:\n${quotes}` : 'メッセージ引用: 保存済み引用はまだありません。'
+        extractionEvidence ? `抽出根拠:\n${extractionEvidence}` : '',
+        quotes ? `メッセージ引用:\n${quotes}` : ''
       ].filter(Boolean).join('\n')
     }
   };
+}
+
+function reasonSourceLabel(reason) {
+  switch (reason.sourceField) {
+    case 'work_styles_and_strengths.dominant_strengths':
+      return '仕事上の強み';
+    case 'work_styles_and_strengths.problem_solving_style':
+      return '問題解決スタイル';
+    case 'current_state.recent_topics_of_interest':
+      return reason.category === 'work_topic' ? '最近の仕事・技術トピック' : '最近の関心・話題';
+    case 'values_and_motivators.core_values':
+      return '価値観';
+    case 'values_and_motivators.motivation_triggers':
+      return '動機・嬉しいこと';
+    default:
+      return '社員データ';
+  }
 }
 
 function chunkResults(results, size = 12) {

--- a/scripts/test-people-finder-rag-search.js
+++ b/scripts/test-people-finder-rag-search.js
@@ -42,11 +42,15 @@ assert(
   'message quotes should be attached to matching facets'
 );
 
-const pokemon = searchFacets(graph, 'ポケモンが好きな人', { category: '興味・人柄', threshold: 0.16 })
-  .map((result) => result.employeeName);
+const pokemonResults = searchFacets(graph, 'ポケモンが好きな人', { category: '興味・人柄', threshold: 0.16 });
+const pokemon = pokemonResults.map((result) => result.employeeName);
 assert(pokemon.includes('小島遼祐'), '小島遼祐 should match pokemon');
 assert(pokemon.includes('藤井芙美子'), '藤井芙美子 should match pokemon');
 assert(pokemon.includes('榎本詩織'), '榎本詩織 should match pokemon');
+assert(
+  pokemonResults.some((result) => result.reasons.some((reason) => reason.label.includes('ポケモン') && reason.sourceField)),
+  'pokemon results should retain the matched source field for evidence display'
+);
 
 const aws = searchFacets(graph, 'AWS運用に詳しい人', { category: '仕事・相談', threshold: 0.16 })
   .map((result) => result.employeeName);

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -392,9 +392,11 @@ function resultMessageBlocks({ query, category, categoryInferred = false, result
 function formatResult(result) {
   const mention = result.slackIds?.[0] ? `<@${result.slackIds[0]}>` : escapeMrkdwn(result.employeeName);
   const reasons = result.reasons
-    .map((reason) => `・${escapeMrkdwn(reason.label)} (${Math.round(reason.score * 100)}%)`)
+    .map((reason) => `・${escapeMrkdwn(reason.label)} (${Math.round(reason.score * 100)}%) - ${escapeMrkdwn(reasonSourceLabel(reason))}`)
     .join('\n');
-  const evidence = result.reasons.find((reason) => reason.evidence)?.evidence;
+  const extractionEvidence = result.reasons
+    .map((reason) => `・「${escapeMrkdwn(reasonSourceLabel(reason))}」に「${escapeMrkdwn(truncate(reason.label, 80))}」が保存されています。`)
+    .join('\n');
   const quotes = result.messageQuotes
     .map((quote) => {
       const quoteText = `「${escapeMrkdwn(truncate(quote.text, 140))}」`;
@@ -409,11 +411,28 @@ function formatResult(result) {
       text: [
         `*${mention}*`,
         `選出理由:\n${reasons || '関連する検索facetが閾値を超えました。'}`,
-        evidence ? `根拠要約: ${escapeMrkdwn(truncate(evidence, 180))}` : '',
-        quotes ? `メッセージ引用:\n${quotes}` : 'メッセージ引用: 保存済み引用はまだありません。'
+        extractionEvidence ? `抽出根拠:\n${extractionEvidence}` : '',
+        quotes ? `メッセージ引用:\n${quotes}` : ''
       ].filter(Boolean).join('\n')
     }
   };
+}
+
+function reasonSourceLabel(reason) {
+  switch (reason.sourceField) {
+    case 'work_styles_and_strengths.dominant_strengths':
+      return '仕事上の強み';
+    case 'work_styles_and_strengths.problem_solving_style':
+      return '問題解決スタイル';
+    case 'current_state.recent_topics_of_interest':
+      return reason.category === 'work_topic' ? '最近の仕事・技術トピック' : '最近の関心・話題';
+    case 'values_and_motivators.core_values':
+      return '価値観';
+    case 'values_and_motivators.motivation_triggers':
+      return '動機・嬉しいこと';
+    default:
+      return '社員データ';
+  }
 }
 
 function searchFacets(facets, query, options = {}) {
@@ -474,6 +493,7 @@ function aggregateByEmployee(scoredFacets, threshold) {
       category: item.facet.category,
       label: item.facet.label,
       score: Number(item.score.toFixed(4)),
+      sourceField: item.facet.sourceField,
       evidence: item.facet.evidence
     });
     result.messageQuotes.push(...(item.facet.messageQuotes || []));


### PR DESCRIPTION
## 概要
- 保存済み引用がない候補では、固定文言の `メッセージ引用: 保存済み引用はまだありません。` を表示しないようにします
- `根拠要約` の汎用summary表示をやめ、検索に一致したfacetが社員データのどの項目に保存されているかを `抽出根拠` として表示します
- 検索結果のreasonに `sourceField` を残し、表示側で `最近の関心・話題` / `仕事上の強み` などの項目名に変換します

## ブランチ・PR戦略
- base: `main`
- working branch: `codex/hide-empty-message-quotes-20260527`
- PRサイズ: 表示ロジック中心の小PR
- 分割基準: 原文メッセージ保存や実データ再生成は別PR

## 確認
- `npm run test:people-finder`
- `npx wrangler --version` -> `4.95.0`
- `npx wrangler deploy --dry-run`

## 表示イメージ
`ポケモンが好きな人` の場合、汎用的な人となりの要約ではなく、`抽出根拠: 「最近の関心・話題」に「ポケモン」が保存されています。` のように表示します。

## 残リスク
- 既存の `search-facets.jsonld` が持つ情報に基づくため、過去分は原文引用ではなく社員データ上のfacet項目が根拠になります