### PR TITLE
社員プロフィールグラフJSON-LDの初期生成を追加

### DIFF
--- a/data/employee-profile-graph.jsonld
+++ b/data/employee-profile-graph.jsonld
@@ -1,0 +1,413 @@
+{
+  "@context": {
+    "saiteki": "https://saiteki.example/schema#",
+    "schema": "https://schema.org/",
+    "person": "saiteki:person/",
+    "topic": "saiteki:topic/",
+    "message": "saiteki:message/",
+    "edge": "saiteki:edge/",
+    "name": "schema:name",
+    "source": "saiteki:source",
+    "target": "saiteki:target",
+    "predicate": "saiteki:predicate",
+    "detailBullets": "saiteki:detailBullets",
+    "evidenceMessages": "saiteki:evidenceMessages"
+  },
+  "generatedAt": "2026-05-27T07:41:01.372Z",
+  "sourceFiles": [
+    "data/employees.json",
+    "data/slack-messages.jsonl",
+    "data/profile-graph-overrides.json"
+  ],
+  "@graph": [
+    {
+      "@id": "person:杉本光一",
+      "@type": "saiteki:Person",
+      "schema:name": "杉本光一",
+      "saiteki:slackIds": [
+        "U09MGV3MU9H",
+        "U08KH52ELPR"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:青木淳一郎",
+      "@type": "saiteki:Person",
+      "schema:name": "青木淳一郎",
+      "saiteki:slackIds": [
+        "U09NHL5HMRN",
+        "U09881886F7"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:小林翔",
+      "@type": "saiteki:Person",
+      "schema:name": "小林翔",
+      "saiteki:slackIds": [
+        "U09S602LZS7"
+      ],
+      "saiteki:job": "QA",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:櫻井志保",
+      "@type": "saiteki:Person",
+      "schema:name": "櫻井志保",
+      "saiteki:slackIds": [
+        "U09S5RCV6GK"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:田浦裕樹",
+      "@type": "saiteki:Person",
+      "schema:name": "田浦裕樹",
+      "saiteki:slackIds": [
+        "U09MM9KS06S",
+        "U09822KG6DT"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:開米 敦則",
+      "@type": "saiteki:Person",
+      "schema:name": "開米 敦則",
+      "saiteki:slackIds": [
+        "U09UHG24VUZ",
+        "U0A69LWD1QF"
+      ],
+      "saiteki:job": "QA",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:貴志雪乃",
+      "@type": "saiteki:Person",
+      "schema:name": "貴志雪乃",
+      "saiteki:slackIds": [
+        "U0A0QFEQGRX"
+      ],
+      "saiteki:job": "HR",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:上遼太郎",
+      "@type": "saiteki:Person",
+      "schema:name": "上遼太郎",
+      "saiteki:slackIds": [
+        "U09NHL467U0",
+        "U0982MZK7E1"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:小松田真伍",
+      "@type": "saiteki:Person",
+      "schema:name": "小松田真伍",
+      "saiteki:slackIds": [
+        "U0A7VHB07J4",
+        "U0AAUUU1LTX"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:小島遼祐",
+      "@type": "saiteki:Person",
+      "schema:name": "小島遼祐",
+      "saiteki:slackIds": [
+        "U0A8H20BWCT"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:藤井芙美子",
+      "@type": "saiteki:Person",
+      "schema:name": "藤井芙美子",
+      "saiteki:slackIds": [
+        "U0A9EE7HZ3P"
+      ],
+      "saiteki:job": "Sales",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:菅野聖也",
+      "@type": "saiteki:Person",
+      "schema:name": "菅野聖也",
+      "saiteki:slackIds": [
+        "U0ADE4H3RTJ"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:佐藤傑",
+      "@type": "saiteki:Person",
+      "schema:name": "佐藤傑",
+      "saiteki:slackIds": [
+        "U09MKUXAU4V"
+      ],
+      "saiteki:job": "Other",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:鈴木悠斗",
+      "@type": "saiteki:Person",
+      "schema:name": "鈴木悠斗",
+      "saiteki:slackIds": [
+        "U09MPBUHTEE",
+        "U08SCMU6544"
+      ],
+      "saiteki:job": "経営",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:戸塚直道",
+      "@type": "saiteki:Person",
+      "schema:name": "戸塚直道",
+      "saiteki:slackIds": [
+        "U09MGUVJ8BV",
+        "U07288UDABX"
+      ],
+      "saiteki:job": "経営",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:榎本詩織",
+      "@type": "saiteki:Person",
+      "schema:name": "榎本詩織",
+      "saiteki:slackIds": [
+        "U0AEE7CDAPK"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:Jun Akiyama",
+      "@type": "saiteki:Person",
+      "schema:name": "Jun Akiyama",
+      "saiteki:slackIds": [
+        "U0AD4UADJ07"
+      ],
+      "saiteki:job": "Other",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:Nakaoka Koshiro",
+      "@type": "saiteki:Person",
+      "schema:name": "Nakaoka Koshiro",
+      "saiteki:slackIds": [
+        "U0B40MREQM6"
+      ],
+      "saiteki:job": "Other",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:Yukinko N0319",
+      "@type": "saiteki:Person",
+      "schema:name": "Yukinko N0319",
+      "saiteki:slackIds": [
+        "U09MSTQ6HQC"
+      ],
+      "saiteki:job": "Other",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:上原基臣",
+      "@type": "saiteki:Person",
+      "schema:name": "上原基臣",
+      "saiteki:slackIds": [
+        "U0AFQUQ1H9R"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:真栄城則明",
+      "@type": "saiteki:Person",
+      "schema:name": "真栄城則明",
+      "saiteki:slackIds": [
+        "U0AGC56822X"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "person:八木橋 雄一",
+      "@type": "saiteki:Person",
+      "schema:name": "八木橋 雄一",
+      "saiteki:slackIds": [
+        "U0AG0UR6LDA"
+      ],
+      "saiteki:job": "Engineer",
+      "saiteki:isActive": true
+    },
+    {
+      "@id": "topic:ゲーム",
+      "@type": "saiteki:Topic",
+      "schema:name": "ゲーム",
+      "saiteki:topicType": "interest",
+      "saiteki:aliases": [
+        "game",
+        "games"
+      ]
+    },
+    {
+      "@id": "topic:ポケモン",
+      "@type": "saiteki:Topic",
+      "schema:name": "ポケモン",
+      "saiteki:topicType": "interest",
+      "saiteki:aliases": [
+        "ポケカ",
+        "Pokemon",
+        "Pokémon",
+        "Pokemon LEGENDS",
+        "ぽこあポケモン"
+      ],
+      "saiteki:parentTopic": "topic:ゲーム"
+    },
+    {
+      "@id": "message:primary:C09Q46YA4ER:1768614261.622119",
+      "@type": "saiteki:SlackMessage",
+      "saiteki:workspace": "primary",
+      "saiteki:channelId": "C09Q46YA4ER",
+      "saiteki:channelName": "自己紹介",
+      "saiteki:messageTs": "1768614261.622119",
+      "saiteki:threadTs": "1768614261.622119",
+      "saiteki:authorSlackId": "U0A8H20BWCT",
+      "saiteki:authorName": "小島　遼祐",
+      "saiteki:textPreview": "皆様はじめまして！ 2026年3月に入社予定の小島遼祐(コジマリョウスケ)と申します。23歳です。よろしくお願いいたします。 •出身地 産まれは愛媛県大洲市 育ちは埼玉県桶川市 現在は大阪府豊中市に住んでいます ・これまでやってきたこと 高校は埼玉県の大宮高校、大学は兵庫県の関西学院大学に通っていました(大学は中退しています)。 IT関連では大学時代に実験のレポートでR言語を触った程度で、ほぼ未経験です。 大学時代に一蘭で1年8ヶ月アルバイトをしており、責任者をしていました。中学時代から代表委員長や部長、各種の実…"
+    },
+    {
+      "@id": "message:primary:C09Q46YA4ER:1772237402.765719",
+      "@type": "saiteki:SlackMessage",
+      "saiteki:workspace": "primary",
+      "saiteki:channelId": "C09Q46YA4ER",
+      "saiteki:channelName": "自己紹介",
+      "saiteki:messageTs": "1772237402.765719",
+      "saiteki:threadTs": "1770701908.083739",
+      "saiteki:authorSlackId": "U0A8H20BWCT",
+      "saiteki:authorName": "小島　遼祐",
+      "saiteki:textPreview": "@榎本 詩織 はじめまして！ 2月から入社した営業の小島と申します。 同じく埼玉出身です。 ご挨拶が遅くなってしまいましたが、これからよろしくお願いします:palms_up_together: 私もポケモンが好きなので色々お話できそうですね:exclamation: 今は小学生から続けているポケカ収集しかできていませんが、時間ができたらゲームもまたしたいな〜とも思ってるので、最近のおすすめのゲーム教えてください！"
+    },
+    {
+      "@id": "message:primary:C09Q46YA4ER:1770701908.083739",
+      "@type": "saiteki:SlackMessage",
+      "saiteki:workspace": "primary",
+      "saiteki:channelId": "C09Q46YA4ER",
+      "saiteki:channelName": "自己紹介",
+      "saiteki:messageTs": "1770701908.083739",
+      "saiteki:threadTs": "1770701908.083739",
+      "saiteki:authorSlackId": "U0AEE7CDAPK",
+      "saiteki:authorName": "榎本 詩織",
+      "saiteki:textPreview": "皆様はじめまして、 6月～7月に入社予定の榎本 詩織（えのもと しおり）と申します。 入社は少し先になりますが、これからどうぞよろしくお願いします。 *◼︎出身地* 生まれも育ちも埼玉県です。 （飛んで埼玉はまだ見てません。そろそろ見たいと思ってます。） *◼︎これまで* 高校で調理師免許を取得し、事務を約2年、飲食業を約４年経験した後、 コロナを機にネットワーク監視や運用保守を約4年経験しました。 現職は温泉施設に併設のレストランで働いています。 *◼︎趣味* ・ポケモン ゲームやポケカ収集、グッズ集め等々… …"
+    },
+    {
+      "@id": "message:primary:C09Q46YA4ER:1772417371.921669",
+      "@type": "saiteki:SlackMessage",
+      "saiteki:workspace": "primary",
+      "saiteki:channelId": "C09Q46YA4ER",
+      "saiteki:channelName": "自己紹介",
+      "saiteki:messageTs": "1772417371.921669",
+      "saiteki:threadTs": "1770701908.083739",
+      "saiteki:authorSlackId": "U0AEE7CDAPK",
+      "saiteki:authorName": "榎本 詩織",
+      "saiteki:textPreview": "@小島 遼祐 さん はじめまして、榎本です。 小島さんの自己紹介も読ませていただきました！ ポケカコレクション、楽しいですよね！ 今や旧裏やEカード、Vシリーズは高値なので中々手が出せませんが…:cry: 小島さんは対戦もされていたとのことなので、 機会があればデッキ編成のコツとか教えてください！ 最近は『Pokémon LEGENDS Z-A』と『マリオカートワールド』をやってます！ 3/5に出る『ぽこあポケモン』も楽しいと思います！ メタモンが色んなポケモンにへんしんして、街づくりするゲームです！ 良かったら…"
+    },
+    {
+      "@id": "message:primary:C09N28KTKL1:1779633198.304519",
+      "@type": "saiteki:SlackMessage",
+      "saiteki:workspace": "primary",
+      "saiteki:channelId": "C09N28KTKL1",
+      "saiteki:channelName": "ソーシャル",
+      "saiteki:messageTs": "1779633198.304519",
+      "saiteki:threadTs": "1779633198.304519",
+      "saiteki:authorSlackId": "U0A9EE7HZ3P",
+      "saiteki:authorName": "藤井芙美子",
+      "saiteki:textPreview": "次男の七五三撮影。 和装も洋装も、 本人の好きなように選ばせたら、 着物はポケモン柄でした:kimono: 流れ作業で進んでいく撮影。 ポーズを指定していいのかもわからず、 バタバタしているうちに、 撮影は前身頃だけで終了。 着替える前に慌てて背中を撮影:sweat_drops: 七五三撮影2回目でも、 こういう時って、 注文していいやら悪いやら、 わからないまま終了する:joy:"
+    },
+    {
+      "@id": "message:primary:C09Q46YA4ER:1779079389.374189",
+      "@type": "saiteki:SlackMessage",
+      "saiteki:workspace": "primary",
+      "saiteki:channelId": "C09Q46YA4ER",
+      "saiteki:channelName": "自己紹介",
+      "saiteki:messageTs": "1779079389.374189",
+      "saiteki:threadTs": "1779001204.657399",
+      "saiteki:authorSlackId": "U0A9EE7HZ3P",
+      "saiteki:authorName": "藤井芙美子",
+      "saiteki:textPreview": "@三本木拓磨 さん はじめまして、総務の藤井といいます:raised_hands: ポケモン大好きなんですね:驚き: Saitekiの営業に、超がつくほどのポケモン好きがいますよ:+1: オンライン飲み会や懇親会など、社員交流の機会ありますので、是非ご参加くださいね"
+    },
+    {
+      "@id": "edge:小島遼祐:COLLECTS:ポケモン",
+      "@type": "saiteki:ProfileEdge",
+      "saiteki:source": "person:小島遼祐",
+      "saiteki:target": "topic:ポケモン",
+      "saiteki:predicate": "COLLECTS",
+      "saiteki:relationLabel": "ポケカ収集・対戦経験あり",
+      "saiteki:detailBullets": [
+        "趣味としてポケモンのゲームやカードを挙げている",
+        "カードは主にコレクションとして楽しんでいる",
+        "ジムバトル参加経験があり、シングルバトルとダブルバトルの経験もある",
+        "小学生から続けているポケカ収集について話している"
+      ],
+      "saiteki:evidenceMessages": [
+        "message:primary:C09Q46YA4ER:1768614261.622119",
+        "message:primary:C09Q46YA4ER:1772237402.765719"
+      ],
+      "saiteki:confidence": 0.95,
+      "saiteki:extractionMethod": "curated_seed",
+      "saiteki:firstSeenAt": "2026-01-17T01:44:21.622Z",
+      "saiteki:updatedAt": "2026-05-27T07:41:01.374Z"
+    },
+    {
+      "@id": "edge:榎本詩織:LIKES:ポケモン",
+      "@type": "saiteki:ProfileEdge",
+      "saiteki:source": "person:榎本詩織",
+      "saiteki:target": "topic:ポケモン",
+      "saiteki:predicate": "LIKES",
+      "saiteki:relationLabel": "ゲーム・ポケカ収集・グッズ集め",
+      "saiteki:detailBullets": [
+        "趣味としてポケモンを挙げている",
+        "ゲーム、ポケカ収集、グッズ集めに触れている",
+        "コロナ以降にハマり、家にグッズが溢れていると話している",
+        "Pokémon LEGENDS Z-A や ぽこあポケモンにも触れている"
+      ],
+      "saiteki:evidenceMessages": [
+        "message:primary:C09Q46YA4ER:1770701908.083739",
+        "message:primary:C09Q46YA4ER:1772417371.921669"
+      ],
+      "saiteki:confidence": 0.96,
+      "saiteki:extractionMethod": "curated_seed",
+      "saiteki:firstSeenAt": "2026-02-10T01:38:28.083Z",
+      "saiteki:updatedAt": "2026-05-27T07:41:01.374Z"
+    },
+    {
+      "@id": "edge:藤井芙美子:FAMILY_CONTEXT:ポケモン",
+      "@type": "saiteki:ProfileEdge",
+      "saiteki:source": "person:藤井芙美子",
+      "saiteki:target": "topic:ポケモン",
+      "saiteki:predicate": "FAMILY_CONTEXT",
+      "saiteki:relationLabel": "家族文脈・社員同士の橋渡し",
+      "saiteki:detailBullets": [
+        "子どもの七五三でポケモン柄の着物を選んだ話をしている",
+        "ポケモン好きの新メンバーに反応している",
+        "社内にポケモン好きがいることを紹介し、交流のきっかけを作っている"
+      ],
+      "saiteki:evidenceMessages": [
+        "message:primary:C09N28KTKL1:1779633198.304519",
+        "message:primary:C09Q46YA4ER:1779079389.374189"
+      ],
+      "saiteki:confidence": 0.86,
+      "saiteki:extractionMethod": "curated_seed",
+      "saiteki:firstSeenAt": "2026-05-18T10:03:18.304Z",
+      "saiteki:updatedAt": "2026-05-27T07:41:01.374Z"
+    }
+  ]
+}

--- a/data/profile-graph-overrides.json
+++ b/data/profile-graph-overrides.json
@@ -1,0 +1,72 @@
+{
+  "topics": [
+    {
+      "id": "topic:ゲーム",
+      "name": "ゲーム",
+      "topicType": "interest",
+      "aliases": ["game", "games"]
+    },
+    {
+      "id": "topic:ポケモン",
+      "name": "ポケモン",
+      "topicType": "interest",
+      "aliases": ["ポケカ", "Pokemon", "Pokémon", "Pokemon LEGENDS", "ぽこあポケモン"],
+      "parentTopic": "topic:ゲーム"
+    }
+  ],
+  "edges": [
+    {
+      "source": "person:小島遼祐",
+      "target": "topic:ポケモン",
+      "predicate": "COLLECTS",
+      "relationLabel": "ポケカ収集・対戦経験あり",
+      "detailBullets": [
+        "趣味としてポケモンのゲームやカードを挙げている",
+        "カードは主にコレクションとして楽しんでいる",
+        "ジムバトル参加経験があり、シングルバトルとダブルバトルの経験もある",
+        "小学生から続けているポケカ収集について話している"
+      ],
+      "evidenceMessageIds": [
+        "primary:C09Q46YA4ER:1768614261.622119",
+        "primary:C09Q46YA4ER:1772237402.765719"
+      ],
+      "confidence": 0.95,
+      "firstSeenAt": "2026-01-17T01:44:21.622Z"
+    },
+    {
+      "source": "person:榎本詩織",
+      "target": "topic:ポケモン",
+      "predicate": "LIKES",
+      "relationLabel": "ゲーム・ポケカ収集・グッズ集め",
+      "detailBullets": [
+        "趣味としてポケモンを挙げている",
+        "ゲーム、ポケカ収集、グッズ集めに触れている",
+        "コロナ以降にハマり、家にグッズが溢れていると話している",
+        "Pokémon LEGENDS Z-A や ぽこあポケモンにも触れている"
+      ],
+      "evidenceMessageIds": [
+        "primary:C09Q46YA4ER:1770701908.083739",
+        "primary:C09Q46YA4ER:1772417371.921669"
+      ],
+      "confidence": 0.96,
+      "firstSeenAt": "2026-02-10T01:38:28.083Z"
+    },
+    {
+      "source": "person:藤井芙美子",
+      "target": "topic:ポケモン",
+      "predicate": "FAMILY_CONTEXT",
+      "relationLabel": "家族文脈・社員同士の橋渡し",
+      "detailBullets": [
+        "子どもの七五三でポケモン柄の着物を選んだ話をしている",
+        "ポケモン好きの新メンバーに反応している",
+        "社内にポケモン好きがいることを紹介し、交流のきっかけを作っている"
+      ],
+      "evidenceMessageIds": [
+        "primary:C09N28KTKL1:1779633198.304519",
+        "primary:C09Q46YA4ER:1779079389.374189"
+      ],
+      "confidence": 0.86,
+      "firstSeenAt": "2026-05-18T10:03:18.304Z"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "saiteki-employee-management",
   "private": true,
   "scripts": {
+    "build:employee-profile-graph": "node scripts/build-employee-profile-graph.js",
     "build:search-facets": "node scripts/build-search-facets.js",
     "build:slack-export-pages": "node scripts/build-slack-export-pages.js",
+    "test:employee-profile-graph": "node scripts/test-employee-profile-graph.js",
     "slack:people-finder": "node scripts/slack-people-finder-app.js",
     "test:people-finder": "node scripts/test-people-finder-rag-search.js"
   },

--- a/scripts/build-employee-profile-graph.js
+++ b/scripts/build-employee-profile-graph.js
@@ -1,0 +1,220 @@
+const fs = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, '../data');
+const EMPLOYEES_FILE = path.join(DATA_DIR, 'employees.json');
+const SLACK_MESSAGES_FILE = path.join(DATA_DIR, 'slack-messages.jsonl');
+const OVERRIDES_FILE = path.join(DATA_DIR, 'profile-graph-overrides.json');
+const OUTPUT_FILE = path.join(DATA_DIR, 'employee-profile-graph.jsonld');
+
+const ALLOWED_PREDICATES = new Set([
+  'LIKES',
+  'INTERESTED_IN',
+  'PLAYS',
+  'COLLECTS',
+  'WATCHES',
+  'LISTENS_TO',
+  'CREATES',
+  'FAMILY_CONTEXT',
+  'CONNECTS_PEOPLE_ON',
+  'HAS_EXPERIENCE_IN',
+  'KNOWS_ABOUT',
+  'CAN_ADVISE_ON',
+  'LEARNING',
+  'OPERATES',
+  'BUILDS',
+  'SUPPORTS'
+]);
+
+const CONTEXT = {
+  saiteki: 'https://saiteki.example/schema#',
+  schema: 'https://schema.org/',
+  person: 'saiteki:person/',
+  topic: 'saiteki:topic/',
+  message: 'saiteki:message/',
+  edge: 'saiteki:edge/',
+  name: 'schema:name',
+  source: 'saiteki:source',
+  target: 'saiteki:target',
+  predicate: 'saiteki:predicate',
+  detailBullets: 'saiteki:detailBullets',
+  evidenceMessages: 'saiteki:evidenceMessages'
+};
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function readJsonl(file) {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function normalizeNodeId(prefix, value) {
+  const text = String(value || '').trim();
+  if (!text) throw new Error(`Missing ${prefix} id value`);
+  return text.startsWith(`${prefix}:`) ? text : `${prefix}:${text}`;
+}
+
+function messageNodeId(messageId) {
+  return normalizeNodeId('message', messageId);
+}
+
+function edgeId(edge) {
+  return edge.id || [
+    'edge',
+    edge.source.replace(/^person:/, ''),
+    edge.predicate,
+    edge.target.replace(/^topic:/, '')
+  ].join(':');
+}
+
+function compactText(value, maxLength = 260) {
+  const text = String(value || '').replace(/\s+/g, ' ').trim();
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+}
+
+function buildPersonNode(employee) {
+  return {
+    '@id': normalizeNodeId('person', employee.name),
+    '@type': 'saiteki:Person',
+    'schema:name': employee.name,
+    'saiteki:slackIds': [employee.slack_id, employee.slack_id_2].filter(Boolean),
+    'saiteki:job': employee.job || '',
+    'saiteki:isActive': employee.isActive !== false
+  };
+}
+
+function buildTopicNode(topic) {
+  return {
+    '@id': normalizeNodeId('topic', topic.id || topic.name),
+    '@type': 'saiteki:Topic',
+    'schema:name': topic.name,
+    'saiteki:topicType': topic.topicType || 'interest',
+    'saiteki:aliases': topic.aliases || [],
+    ...(topic.parentTopic ? { 'saiteki:parentTopic': normalizeNodeId('topic', topic.parentTopic) } : {})
+  };
+}
+
+function buildMessageNode(message) {
+  return {
+    '@id': messageNodeId(message.id),
+    '@type': 'saiteki:SlackMessage',
+    'saiteki:workspace': message.workspace || 'primary',
+    'saiteki:channelId': message.channelId || '',
+    'saiteki:channelName': message.channelName || '',
+    'saiteki:messageTs': message.messageTs || '',
+    'saiteki:threadTs': message.threadTs || null,
+    'saiteki:authorSlackId': message.user || '',
+    'saiteki:authorName': message.userName || '',
+    'saiteki:textPreview': compactText(message.text || message.rawText || '')
+  };
+}
+
+function buildProfileEdge(edge) {
+  return {
+    '@id': edgeId(edge),
+    '@type': 'saiteki:ProfileEdge',
+    'saiteki:source': normalizeNodeId('person', edge.source),
+    'saiteki:target': normalizeNodeId('topic', edge.target),
+    'saiteki:predicate': edge.predicate,
+    'saiteki:relationLabel': edge.relationLabel || edge.predicate,
+    'saiteki:detailBullets': edge.detailBullets || [],
+    'saiteki:evidenceMessages': (edge.evidenceMessageIds || []).map(messageNodeId),
+    'saiteki:confidence': edge.confidence,
+    'saiteki:extractionMethod': edge.extractionMethod || 'curated_seed',
+    'saiteki:firstSeenAt': edge.firstSeenAt || null,
+    'saiteki:updatedAt': edge.updatedAt || new Date().toISOString()
+  };
+}
+
+function validateProfileGraph(graph, slackMessages) {
+  const nodes = graph['@graph'] || [];
+  const nodeIds = new Set(nodes.map((node) => node['@id']));
+  const messageIds = new Set(slackMessages.map((message) => messageNodeId(message.id)));
+  const edgeKeys = new Set();
+  const errors = [];
+
+  for (const node of nodes.filter((item) => item['@type'] === 'saiteki:ProfileEdge')) {
+    const source = node['saiteki:source'];
+    const target = node['saiteki:target'];
+    const predicate = node['saiteki:predicate'];
+    const key = `${source}|${predicate}|${target}`;
+    const evidence = node['saiteki:evidenceMessages'] || [];
+    const confidence = node['saiteki:confidence'];
+
+    if (!nodeIds.has(source)) errors.push(`${node['@id']} source is missing: ${source}`);
+    if (!nodeIds.has(target)) errors.push(`${node['@id']} target is missing: ${target}`);
+    if (!ALLOWED_PREDICATES.has(predicate)) errors.push(`${node['@id']} predicate is not allowed: ${predicate}`);
+    if (edgeKeys.has(key)) errors.push(`${node['@id']} duplicates edge key: ${key}`);
+    edgeKeys.add(key);
+    if (!Array.isArray(node['saiteki:detailBullets']) || node['saiteki:detailBullets'].length === 0) {
+      errors.push(`${node['@id']} has no detail bullets`);
+    }
+    if (typeof confidence !== 'number' || confidence < 0 || confidence > 1) {
+      errors.push(`${node['@id']} confidence must be between 0 and 1`);
+    }
+    if (evidence.length === 0) errors.push(`${node['@id']} has no evidence messages`);
+    for (const id of evidence) {
+      if (!messageIds.has(id)) errors.push(`${node['@id']} evidence message is missing: ${id}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid employee profile graph:\n${errors.join('\n')}`);
+  }
+}
+
+function buildEmployeeProfileGraph({ employees, slackMessages, overrides, generatedAt = new Date().toISOString() }) {
+  const activeEmployees = employees.filter((employee) => employee.isActive !== false);
+  const referencedMessageIds = new Set((overrides.edges || [])
+    .flatMap((edge) => edge.evidenceMessageIds || [])
+    .map(messageNodeId));
+  const messageByNodeId = new Map(slackMessages.map((message) => [messageNodeId(message.id), message]));
+
+  const graph = [
+    ...activeEmployees.map(buildPersonNode),
+    ...(overrides.topics || []).map(buildTopicNode),
+    ...[...referencedMessageIds]
+      .map((id) => messageByNodeId.get(id))
+      .filter(Boolean)
+      .map(buildMessageNode),
+    ...(overrides.edges || []).map(buildProfileEdge)
+  ];
+
+  const payload = {
+    '@context': CONTEXT,
+    generatedAt,
+    sourceFiles: [
+      'data/employees.json',
+      'data/slack-messages.jsonl',
+      'data/profile-graph-overrides.json'
+    ],
+    '@graph': graph
+  };
+  validateProfileGraph(payload, slackMessages);
+  return payload;
+}
+
+function main() {
+  const employees = readJson(EMPLOYEES_FILE);
+  const slackMessages = readJsonl(SLACK_MESSAGES_FILE);
+  const overrides = readJson(OVERRIDES_FILE);
+  const graph = buildEmployeeProfileGraph({ employees, slackMessages, overrides });
+  fs.writeFileSync(OUTPUT_FILE, `${JSON.stringify(graph, null, 2)}\n`);
+  console.log(`Generated ${graph['@graph'].length} profile graph nodes at ${OUTPUT_FILE}`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  ALLOWED_PREDICATES,
+  buildEmployeeProfileGraph,
+  validateProfileGraph
+};

--- a/scripts/test-employee-profile-graph.js
+++ b/scripts/test-employee-profile-graph.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const {
+  buildEmployeeProfileGraph,
+  validateProfileGraph
+} = require('./build-employee-profile-graph');
+
+const DATA_DIR = path.join(__dirname, '../data');
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function readJsonl(file) {
+  return fs.readFileSync(file, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+const employees = readJson(path.join(DATA_DIR, 'employees.json'));
+const slackMessages = readJsonl(path.join(DATA_DIR, 'slack-messages.jsonl'));
+const overrides = readJson(path.join(DATA_DIR, 'profile-graph-overrides.json'));
+
+const graph = buildEmployeeProfileGraph({
+  employees,
+  slackMessages,
+  overrides,
+  generatedAt: '2026-05-27T00:00:00.000Z'
+});
+const nodes = graph['@graph'];
+
+assert(nodes.some((node) => node['@id'] === 'person:小島遼祐' && node['@type'] === 'saiteki:Person'));
+assert(nodes.some((node) => node['@id'] === 'topic:ポケモン' && node['@type'] === 'saiteki:Topic'));
+assert(nodes.some((node) => node['@id'] === 'message:primary:C09Q46YA4ER:1772237402.765719'));
+
+const edges = nodes.filter((node) => node['@type'] === 'saiteki:ProfileEdge');
+assert.strictEqual(edges.length, 3, 'seed graph should have three pokemon profile edges');
+
+const kojima = edges.find((edge) => edge['saiteki:source'] === 'person:小島遼祐');
+assert(kojima, '小島遼祐 edge should exist');
+assert.strictEqual(kojima['saiteki:target'], 'topic:ポケモン');
+assert.strictEqual(kojima['saiteki:predicate'], 'COLLECTS');
+assert(
+  kojima['saiteki:detailBullets'].some((bullet) => bullet.includes('ジムバトル')),
+  '小島遼祐 edge should preserve concrete pokemon details'
+);
+assert(
+  kojima['saiteki:evidenceMessages'].every((id) => id.startsWith('message:primary:')),
+  'evidence message ids should be JSON-LD message node ids'
+);
+
+const invalid = JSON.parse(JSON.stringify(graph));
+invalid['@graph'].find((node) => node['@type'] === 'saiteki:ProfileEdge')['saiteki:evidenceMessages'] = [];
+assert.throws(
+  () => validateProfileGraph(invalid, slackMessages),
+  /has no evidence messages/,
+  'validator should reject edges without evidence'
+);
+
+console.log('employee profile graph OK');


### PR DESCRIPTION
## 概要
- `data/employee-profile-graph.jsonld` を生成する初期スクリプトを追加しました。
- `Person`, `Topic`, `SlackMessage`, `ProfileEdge` のJSON-LD構造を出力します。
- ポケモンのseed接点として、小島遼祐さん・榎本詩織さん・藤井芙美子さんの3 edgesを追加しました。
- `ProfileEdge` はNeo4j的に `Person -[COLLECTS/LIKES/FAMILY_CONTEXT]-> Topic` へ変換できる形で、具体メモと根拠Slackメッセージを持ちます。
- 根拠なしエッジ、存在しない人物/トピック/メッセージ、未許可predicateを落とすvalidatorを追加しました。

## ブランチ・PR戦略
- base: `main`
- working branch: `codex/employee-profile-graph-core-20260527`
- PR size budget: 生成JSON-LDを含むため大きめ。今回は初期スキーマ・生成器・seedデータに限定
- split criteria: LLM抽出、`search-facets.jsonld` 派生化、Slack App表示切替、日次同期組み込みは別PRに分割

## 生成結果
- `saiteki:Person`: 22
- `saiteki:Topic`: 2
- `saiteki:SlackMessage`: 6
- `saiteki:ProfileEdge`: 3

## 検証
- `node --check scripts/build-employee-profile-graph.js`
- `node --check scripts/test-employee-profile-graph.js`
- `npm run test:employee-profile-graph`
- `npm run build:employee-profile-graph`
- `npm run test:people-finder`
- `git diff --cached --check`

## 残リスク
- 今回はcurated seed方式です。Slack原文からのLLM抽出はまだ入れていません。
- `search-facets.jsonld` はまだ `employee-profile-graph.jsonld` 由来には切り替えていません。
- 日次同期への組み込みは次以降のPRで行います。