### PR TITLE
プロフィール検索indexのembeddingとベクトル検索を追加

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 data/slack-messages.jsonl linguist-generated=true
 data/profile-search-index.json linguist-generated=true
+data/profile-search-index.embedded.json linguist-generated=true
 docs/slack-export/slack-export-data.js linguist-generated=true

--- a/data/profile-graph/README.md
+++ b/data/profile-graph/README.md
@@ -11,9 +11,14 @@
 手作業で補正する高品質な関係は `generated/` の外に置きます。
 
 Slack検索やRAGで読む `data/employee-profile-graph.jsonld` と
-`data/search-facets.jsonld`、`data/profile-search-index.json` は生成物です。直接編集せず、
+`data/search-facets.jsonld`、`data/profile-search-index.json`、
+`data/profile-search-index.embedded.json` は生成物です。直接編集せず、
 このディレクトリの正本から再生成します。
 
 `data/profile-search-index.json` はembedding生成前の検索単位indexです。
 `ProfileEdge` ごとに、社員、トピック、根拠、引用、`searchText`、
 内部用の `semanticType` をまとめます。
+
+`data/profile-search-index.embedded.json` は `npm run embed:profile-search-index`
+で生成するembeddingつきindexです。通常は `GEMINI_API_KEY` を使います。
+テスト時だけ `-- --provider local-fixture` を指定できます。

--- a/package.json
+++ b/package.json
@@ -5,11 +5,14 @@
     "backfill:profile-graph": "node scripts/backfill-profile-graph-source.js",
     "build:employee-profile-graph": "node scripts/build-employee-profile-graph.js",
     "build:profile-search-index": "node scripts/build-profile-search-index.js",
+    "embed:profile-search-index": "node scripts/embed-profile-search-index.js",
     "build:search-facets": "npm run backfill:profile-graph && npm run build:employee-profile-graph && node scripts/build-search-facets.js && npm run build:profile-search-index",
     "build:slack-export-pages": "node scripts/build-slack-export-pages.js",
+    "search:profile-vector": "node scripts/people-finder-vector-search.js",
     "slack:people-finder": "node scripts/slack-people-finder-app.js",
     "test:employee-profile-graph": "node scripts/test-employee-profile-graph.js",
     "test:profile-search-index": "node scripts/test-profile-search-index.js",
+    "test:profile-vector-search": "node scripts/test-profile-vector-search.js",
     "test:people-finder": "node scripts/test-people-finder-rag-search.js"
   },
   "dependencies": {

--- a/scripts/embed-profile-search-index.js
+++ b/scripts/embed-profile-search-index.js
@@ -1,0 +1,122 @@
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config({ quiet: true });
+
+const { createEmbeddingProvider, textHash } = require('./profile-embedding-utils');
+
+const DATA_DIR = path.join(__dirname, '../data');
+const INPUT_FILE = path.join(DATA_DIR, 'profile-search-index.json');
+const OUTPUT_FILE = path.join(DATA_DIR, 'profile-search-index.embedded.json');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index++) {
+    const value = argv[index];
+    if (!value.startsWith('--')) continue;
+    const key = value.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      index++;
+    }
+  }
+  return args;
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function existingEmbeddingMap(outputFile, provider) {
+  if (!fs.existsSync(outputFile)) return new Map();
+  const existing = readJson(outputFile);
+  const map = new Map();
+  for (const unit of existing['@graph'] || []) {
+    if (!unit.embedding?.vector || unit.embedding.provider !== provider.name || unit.embedding.model !== provider.model) continue;
+    map.set(unit['@id'], unit.embedding);
+  }
+  return map;
+}
+
+async function embedProfileSearchIndex(index, provider, options = {}) {
+  const existing = existingEmbeddingMap(options.outputFile || OUTPUT_FILE, provider);
+  const limit = Number(options.limit || 0);
+  let generated = 0;
+  let reused = 0;
+
+  const units = [];
+  for (const unit of index['@graph'] || []) {
+    const hash = textHash(unit.searchText || '');
+    const previous = existing.get(unit['@id']);
+    let embedding = previous && previous.textHash === hash ? previous : null;
+    if (embedding) {
+      reused++;
+    } else {
+      if (limit > 0 && generated >= limit) {
+        units.push(unit);
+        continue;
+      }
+      const vector = await provider.embed(unit.searchText || '', 'document');
+      embedding = {
+        provider: provider.name,
+        model: provider.model,
+        textHash: hash,
+        dimensions: vector.length,
+        vector
+      };
+      generated++;
+    }
+    units.push({ ...unit, embedding });
+  }
+
+  return {
+    ...index,
+    generatedAt: new Date().toISOString(),
+    embedding: {
+      status: limit > 0 && generated >= limit ? 'partial' : 'generated',
+      provider: provider.name,
+      model: provider.model,
+      sourceTextField: 'searchText',
+      generated,
+      reused
+    },
+    '@graph': units
+  };
+}
+
+function writeEmbeddedIndex(index, outputFile = OUTPUT_FILE) {
+  fs.writeFileSync(outputFile, `${JSON.stringify(index, null, 2)}\n`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const inputFile = args.input || INPUT_FILE;
+  const outputFile = args.output || OUTPUT_FILE;
+  const provider = await createEmbeddingProvider({
+    provider: args.provider,
+    model: args.model,
+    dimensions: args.dimensions
+  });
+  const index = readJson(inputFile);
+  const embedded = await embedProfileSearchIndex(index, provider, {
+    outputFile,
+    limit: args.limit
+  });
+  writeEmbeddedIndex(embedded, outputFile);
+  console.log(`Embedded ${embedded['@graph'].filter((unit) => unit.embedding?.vector).length} profile search units at ${outputFile}`);
+  console.log(`Provider: ${provider.name} / ${provider.model}`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  embedProfileSearchIndex,
+  writeEmbeddedIndex
+};

--- a/scripts/people-finder-vector-search.js
+++ b/scripts/people-finder-vector-search.js
@@ -1,0 +1,163 @@
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config({ quiet: true });
+
+const {
+  cosineSimilarity,
+  createEmbeddingProvider,
+  normalizeText,
+  stripQueryHelpers,
+  tokenize
+} = require('./profile-embedding-utils');
+
+const DEFAULT_INDEX_FILE = path.join(__dirname, '../data/profile-search-index.embedded.json');
+const DEFAULT_THRESHOLD = 0.22;
+const DEFAULT_TOP_UNITS = 80;
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index++) {
+    const value = argv[index];
+    if (!value.startsWith('--')) continue;
+    const key = value.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      index++;
+    }
+  }
+  return args;
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function unitVector(unit) {
+  if (Array.isArray(unit.embedding)) return unit.embedding;
+  return unit.embedding?.vector || [];
+}
+
+function ensureEmbedded(index) {
+  const missing = (index['@graph'] || []).filter((unit) => unitVector(unit).length === 0);
+  if (missing.length > 0) {
+    throw new Error(`Embedded index has ${missing.length} units without vectors. Run scripts/embed-profile-search-index.js first.`);
+  }
+}
+
+function aggregateByEmployee(scoredUnits, threshold) {
+  const byEmployee = new Map();
+  for (const item of scoredUnits) {
+    if (item.score < threshold) continue;
+    const key = item.unit.personName;
+    if (!byEmployee.has(key)) {
+      byEmployee.set(key, {
+        employeeName: key,
+        slackIds: item.unit.slackIds || [],
+        score: item.score,
+        reasons: [],
+        quotes: []
+      });
+    }
+    const result = byEmployee.get(key);
+    result.score = Math.max(result.score, item.score);
+    result.reasons.push({
+      unitId: item.unit['@id'],
+      edge: item.unit.edge,
+      semanticType: item.unit.semanticType,
+      uiCategory: item.unit.uiCategory,
+      category: item.unit.category,
+      relationLabel: item.unit.relationLabel,
+      topicLabel: item.unit.topicLabel,
+      score: Number(item.score.toFixed(4)),
+      detailBullets: item.unit.detailBullets || []
+    });
+    result.quotes.push(...(item.unit.quotes || []));
+  }
+
+  return [...byEmployee.values()]
+    .map((result) => ({
+      ...result,
+      score: Number(result.score.toFixed(4)),
+      reasons: result.reasons.sort((a, b) => b.score - a.score).slice(0, 3),
+      quotes: dedupeQuotes(result.quotes).slice(0, 3)
+    }))
+    .sort((a, b) => b.score - a.score || a.employeeName.localeCompare(b.employeeName, 'ja'));
+}
+
+function dedupeQuotes(quotes) {
+  const seen = new Set();
+  const unique = [];
+  for (const quote of quotes) {
+    const key = `${quote.messageId}:${quote.text}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(quote);
+  }
+  return unique;
+}
+
+function lexicalLabelBoost(unit, queryText) {
+  const labelText = normalizeText([
+    unit.relationLabel,
+    unit.topicLabel,
+    ...(unit.topicAliases || [])
+  ].filter(Boolean).join(' '));
+  if (!labelText) return 0;
+  const terms = tokenize(queryText).filter((term) => term.length >= 2);
+  const matched = terms.filter((term) => labelText.includes(term)).length;
+  return Math.min(matched * 0.06, 0.18);
+}
+
+async function searchProfileVectors(index, query, provider, options = {}) {
+  ensureEmbedded(index);
+  const threshold = Number(options.threshold ?? DEFAULT_THRESHOLD);
+  const topUnits = Number(options.topUnits || DEFAULT_TOP_UNITS);
+  const queryText = stripQueryHelpers(query) || normalizeText(query);
+  const queryVector = await provider.embed(queryText, 'query');
+
+  const scoredUnits = (index['@graph'] || [])
+    .map((unit) => ({
+      unit,
+      score: cosineSimilarity(queryVector, unitVector(unit)) + lexicalLabelBoost(unit, queryText)
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topUnits);
+
+  return aggregateByEmployee(scoredUnits, threshold);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const query = args.query || args.q;
+  if (!query) {
+    console.error('Usage: node scripts/people-finder-vector-search.js --query "QAエンジニア" --file data/profile-search-index.embedded.json');
+    process.exit(1);
+  }
+  const file = args.file || DEFAULT_INDEX_FILE;
+  const index = readJson(file);
+  const provider = await createEmbeddingProvider({
+    provider: args.provider || index.embedding?.provider,
+    model: args.model || index.embedding?.model,
+    dimensions: args.dimensions
+  });
+  const results = await searchProfileVectors(index, query, provider, {
+    threshold: args.threshold,
+    topUnits: args['top-units']
+  });
+  console.log(JSON.stringify({ query, results }, null, 2));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  aggregateByEmployee,
+  searchProfileVectors
+};

--- a/scripts/profile-embedding-utils.js
+++ b/scripts/profile-embedding-utils.js
@@ -1,0 +1,167 @@
+const crypto = require('crypto');
+
+const DEFAULT_LOCAL_DIMENSIONS = 1024;
+const DEFAULT_GEMINI_EMBEDDING_MODEL = 'text-embedding-004';
+
+const LOCAL_SYNONYMS = {
+  qa: ['品質保証', 'テスト', 'テスト設計', '総合テスト', '検証', '不具合'],
+  品質保証: ['qa', 'テスト', '検証'],
+  テスト: ['qa', '品質保証', '検証', 'テスト設計'],
+  aws: ['クラウド', '運用', '監視', 'インフラ'],
+  ポケモン: ['pokemon', 'pokémon', 'ポケカ', 'ゲーム'],
+  ポケカ: ['ポケモン', 'pokemon', 'カード'],
+  ガンダム: ['ロボット作品', 'ゲーム', 'gundam']
+};
+
+function normalizeText(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[・、。,.!?！？:：;；()[\]{}「」『』"']/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function stripQueryHelpers(query) {
+  return normalizeText(query)
+    .replace(/が好きな人|が好き|好きな人|好きな|興味がある人|詳しい人|得意な人|できる人|話せる人|相談できる人|相談したい|人/g, ' ')
+    .replace(/を知っている人|を知っている|知っている人|知っている|知ってる|分かる|わかる|経験者|または|もしくは|あるいは/g, ' ')
+    .replace(/について|に関心がある|に興味がある|を探して|探して|教えて|詳しい|相談/g, ' ')
+    .replace(/([a-z0-9+#.])([^a-z0-9+#.\s])/g, '$1 $2')
+    .replace(/([^a-z0-9+#.\s])([a-z0-9+#.])/g, '$1 $2')
+    .replace(/(^|\s)(に|を|が|は|の|と|で)(?=\s|$)/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function addNgrams(tokens, text, size) {
+  const chars = [...text.replace(/\s+/g, '')];
+  if (chars.length < size) return;
+  for (let index = 0; index <= chars.length - size; index++) {
+    tokens.push(chars.slice(index, index + size).join(''));
+  }
+}
+
+function tokenize(value) {
+  const normalized = normalizeText(value);
+  const tokens = [];
+  const words = normalized.split(/\s+/).filter((word) => word.length >= 2);
+  tokens.push(...words);
+  tokens.push(...(normalized.match(/[a-z0-9+#.]{2,}/g) || []));
+
+  const japaneseSegments = normalized
+    .replace(/[a-z0-9+#.]+/g, ' ')
+    .split(/\s+/)
+    .filter((segment) => segment.length >= 2);
+  for (const segment of japaneseSegments) {
+    addNgrams(tokens, segment, 2);
+    addNgrams(tokens, segment, 3);
+  }
+
+  for (const [term, synonyms] of Object.entries(LOCAL_SYNONYMS)) {
+    if (normalized.includes(normalizeText(term))) {
+      tokens.push(...synonyms.map(normalizeText));
+    }
+  }
+
+  return [...new Set(tokens.filter(Boolean))];
+}
+
+function stableHash(value) {
+  return crypto.createHash('sha256').update(String(value)).digest();
+}
+
+function textHash(value) {
+  return crypto.createHash('sha256').update(String(value || '')).digest('hex');
+}
+
+function normalizeVector(vector) {
+  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  if (!norm) return vector;
+  return vector.map((value) => Number((value / norm).toFixed(8)));
+}
+
+function localFixtureEmbedding(text, dimensions = DEFAULT_LOCAL_DIMENSIONS) {
+  const vector = Array(dimensions).fill(0);
+  for (const token of tokenize(text)) {
+    const hash = stableHash(token);
+    const index = hash.readUInt32BE(0) % dimensions;
+    vector[index] += 1;
+  }
+  return normalizeVector(vector);
+}
+
+function cosineSimilarity(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return 0;
+  let dot = 0;
+  let aNorm = 0;
+  let bNorm = 0;
+  for (let index = 0; index < a.length; index++) {
+    dot += a[index] * b[index];
+    aNorm += a[index] * a[index];
+    bNorm += b[index] * b[index];
+  }
+  if (!aNorm || !bNorm) return 0;
+  return dot / (Math.sqrt(aNorm) * Math.sqrt(bNorm));
+}
+
+function createLocalFixtureProvider(options = {}) {
+  const dimensions = Number(options.dimensions || DEFAULT_LOCAL_DIMENSIONS);
+  return {
+    name: 'local-fixture',
+    model: `local-hash-v1-${dimensions}`,
+    dimensions,
+    async embed(text) {
+      return localFixtureEmbedding(text, dimensions);
+    }
+  };
+}
+
+function resolveProviderName(providerName) {
+  return providerName || process.env.PROFILE_EMBEDDING_PROVIDER || 'gemini';
+}
+
+async function createEmbeddingProvider(options = {}) {
+  const providerName = resolveProviderName(options.provider);
+  if (providerName === 'local-fixture') {
+    return createLocalFixtureProvider(options);
+  }
+  if (providerName !== 'gemini') {
+    throw new Error(`Unknown embedding provider: ${providerName}`);
+  }
+
+  const apiKey = options.apiKey || process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error('GEMINI_API_KEY is required for gemini embedding provider. Use --provider local-fixture for tests.');
+  }
+
+  const { GoogleGenerativeAI, TaskType } = require('@google/generative-ai');
+  const modelName = options.model || process.env.GEMINI_EMBEDDING_MODEL || DEFAULT_GEMINI_EMBEDDING_MODEL;
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({ model: modelName });
+
+  return {
+    name: 'gemini',
+    model: modelName,
+    dimensions: null,
+    async embed(text, task = 'document') {
+      const taskType = task === 'query' ? TaskType.RETRIEVAL_QUERY : TaskType.RETRIEVAL_DOCUMENT;
+      const response = await model.embedContent({
+        content: { role: 'user', parts: [{ text }] },
+        taskType
+      });
+      return response.embedding.values;
+    }
+  };
+}
+
+module.exports = {
+  cosineSimilarity,
+  createEmbeddingProvider,
+  createLocalFixtureProvider,
+  localFixtureEmbedding,
+  normalizeText,
+  stripQueryHelpers,
+  textHash,
+  tokenize
+};

--- a/scripts/test-profile-vector-search.js
+++ b/scripts/test-profile-vector-search.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { buildProfileSearchIndex } = require('./build-profile-search-index');
+const { embedProfileSearchIndex, writeEmbeddedIndex } = require('./embed-profile-search-index');
+const { searchProfileVectors } = require('./people-finder-vector-search');
+const { createLocalFixtureProvider } = require('./profile-embedding-utils');
+
+async function main() {
+  const profileGraph = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/employee-profile-graph.jsonld'), 'utf8'));
+  const index = buildProfileSearchIndex(profileGraph, '2026-05-27T00:00:00.000Z');
+  const provider = createLocalFixtureProvider({ dimensions: 1024 });
+  const embedded = await embedProfileSearchIndex(index, provider, {
+    outputFile: path.join(os.tmpdir(), 'missing-profile-search-index.embedded.json')
+  });
+
+  assert.strictEqual(embedded.embedding.status, 'generated');
+  assert.strictEqual(embedded.embedding.provider, 'local-fixture');
+  assert.strictEqual(embedded['@graph'].length, index['@graph'].length);
+  assert(embedded['@graph'].every((unit) => unit.embedding?.vector?.length === 1024));
+
+  const pokemon = await searchProfileVectors(embedded, 'ポケカが好きな人', provider, {
+    threshold: 0.15,
+    topUnits: 60
+  });
+  const pokemonNames = pokemon.map((result) => result.employeeName);
+  assert(pokemonNames.includes('小島遼祐'), '小島遼祐 should match Pokemon card query');
+  assert(pokemonNames.includes('榎本詩織'), '榎本詩織 should match Pokemon card query');
+  assert(
+    pokemon.some((result) => result.quotes.some((quote) => quote.text.includes('ポケカ'))),
+    'pokemon vector results should preserve concrete message quotes'
+  );
+
+  const qa = await searchProfileVectors(embedded, 'QAエンジニア', provider, {
+    threshold: 0.18,
+    topUnits: 80
+  });
+  const kaimai = qa.find((result) => result.employeeName === '開米 敦則');
+  assert(kaimai, '開米 敦則 should match QA engineer query');
+  assert(
+    kaimai.reasons.some((reason) => reason.relationLabel.includes('QAエンジニアリング')),
+    'QA result should expose the direct QA engineering reason'
+  );
+  assert(
+    kaimai.quotes.some((quote) => quote.text.includes('QAエンジニア')),
+    'QA result should include a QA quote'
+  );
+
+  const testWork = await searchProfileVectors(embedded, 'テスト業務の経験者', provider, {
+    threshold: 0.18,
+    topUnits: 80
+  });
+  assert(
+    testWork.some((result) => result.employeeName === '上原基臣'),
+    '上原基臣 should match test work experience query'
+  );
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'profile-vector-search-'));
+  const tempFile = path.join(tempDir, 'profile-search-index.embedded.json');
+  writeEmbeddedIndex(embedded, tempFile);
+  const written = JSON.parse(fs.readFileSync(tempFile, 'utf8'));
+  assert.strictEqual(written['@graph'].length, embedded['@graph'].length);
+
+  console.log('profile vector search OK');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要
`profile-search-index.json` をembedding化し、ローカルでベクトル検索できる経路を追加しました。

- `scripts/embed-profile-search-index.js` を追加
  - 本番用途では `GEMINI_API_KEY` を使ってGemini embeddingを生成
  - テスト用途では `--provider local-fixture` で決定的なfixture embeddingを生成
- `scripts/people-finder-vector-search.js` を追加
  - 埋め込み済みindexを読み込み、クエリembeddingとのcosine similarityで近傍検索
  - 検索単位を社員ごとに集約し、理由と引用を返す
- `scripts/profile-embedding-utils.js` を追加
  - Gemini/local-fixture provider、cosine similarity、クエリ補助語の除去を共通化
- `scripts/test-profile-vector-search.js` を追加
  - APIキーなしでベクトル検索の回帰を確認

## 使い方

Gemini embeddingを生成する場合:

```bash
GEMINI_API_KEY=... npm run embed:profile-search-index
```

ローカルfixtureで試す場合:

```bash
npm run embed:profile-search-index -- --provider local-fixture --output /tmp/profile-search-index.embedded.json
npm run search:profile-vector -- --provider local-fixture --file /tmp/profile-search-index.embedded.json --query "QAエンジニア"
```

## 確認したこと

local-fixtureで `QAエンジニア` を検索すると、少なくとも以下が上位候補に入ることを確認しています。

- 開米 敦則: `QAエンジニアリングの専門知識と長年の経験`
- 上原基臣: `総合テスト` / `サーバ運用・テスト経験`

## ブランチ・PR戦略

- base branch: `main`
- working branch: `codex/profile-vector-search-20260527`
- PRサイズ: embedding生成とローカル検索が密接なので同一PRにしています。Worker反映とAI再ランキングは含めず、後続PRへ分離します
- split criteria: Slack Worker差し替え、AI再ランキング、実Gemini embedding生成済みデータの反映は別PR
- 次PR: AI再ランキング、または実Gemini embedding生成済みindexの反映

## テスト

- `node --check scripts/profile-embedding-utils.js`
- `node --check scripts/embed-profile-search-index.js`
- `node --check scripts/people-finder-vector-search.js`
- `node --check scripts/test-profile-vector-search.js`
- `npm run test:profile-search-index`
- `npm run test:profile-vector-search`
- `npm run test:employee-profile-graph`
- `npm run test:people-finder`
- `git diff --check`

## 残リスク

- このPRでは実Gemini API呼び出しは検証していません。ローカル環境に `GEMINI_API_KEY` がないため、テストは `local-fixture` で行っています。
- local-fixtureはCI/テスト用であり、検索品質評価用ではありません。実運用の精度確認はGemini embedding生成後に行います。
- `QAエンジニア` の周辺ノイズ除去は、次のAI再ランキングPRで対応します。