### PR TITLE
ベクトル検索結果のAI再ランキングを追加

### DIFF
--- a/data/profile-graph/README.md
+++ b/data/profile-graph/README.md
@@ -22,3 +22,8 @@ Slack検索やRAGで読む `data/employee-profile-graph.jsonld` と
 `data/profile-search-index.embedded.json` は `npm run embed:profile-search-index`
 で生成するembeddingつきindexです。通常は `GEMINI_API_KEY` を使います。
 テスト時だけ `-- --provider local-fixture` を指定できます。
+
+ベクトル検索結果をAIで再評価する場合は `npm run search:profile-vector -- --rerank`
+を使います。通常はGeminiで `direct` / `adjacent` / `weak` / `reject`
+を判定し、テスト時だけ `--reranker local-fixture` を指定できます。
+`direct` だけを表示したい場合は `--direct-only` を追加します。

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:employee-profile-graph": "node scripts/test-employee-profile-graph.js",
     "test:profile-search-index": "node scripts/test-profile-search-index.js",
     "test:profile-vector-search": "node scripts/test-profile-vector-search.js",
+    "test:people-finder-rerank": "node scripts/test-people-finder-rerank.js",
     "test:people-finder": "node scripts/test-people-finder-rag-search.js"
   },
   "dependencies": {

--- a/scripts/people-finder-vector-search.js
+++ b/scripts/people-finder-vector-search.js
@@ -9,6 +9,7 @@ const {
   stripQueryHelpers,
   tokenize
 } = require('./profile-embedding-utils');
+const { createReranker, rerankPeopleResults } = require('./rerank-people-finder-results');
 
 const DEFAULT_INDEX_FILE = path.join(__dirname, '../data/profile-search-index.embedded.json');
 const DEFAULT_THRESHOLD = 0.22;
@@ -147,7 +148,16 @@ async function main() {
     threshold: args.threshold,
     topUnits: args['top-units']
   });
-  console.log(JSON.stringify({ query, results }, null, 2));
+  const finalResults = args.rerank
+    ? await rerankPeopleResults(query, results, await createReranker({
+      provider: args.reranker,
+      model: args['rerank-model']
+    }), {
+      candidateLimit: args['rerank-candidates'],
+      includeAdjacent: !args['direct-only'] && args['include-adjacent'] !== 'false'
+    })
+    : results;
+  console.log(JSON.stringify({ query, results: finalResults }, null, 2));
 }
 
 if (require.main === module) {

--- a/scripts/rerank-people-finder-results.js
+++ b/scripts/rerank-people-finder-results.js
@@ -1,0 +1,239 @@
+require('dotenv').config({ quiet: true });
+
+const { normalizeText, tokenize } = require('./profile-embedding-utils');
+
+const INTENT_RANK = {
+  direct: 4,
+  adjacent: 3,
+  weak: 2,
+  reject: 1
+};
+
+function parseJsonText(text) {
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end === -1) throw new Error(`AI rerank response is not JSON: ${text.slice(0, 200)}`);
+  return JSON.parse(text.slice(start, end + 1));
+}
+
+function compactReason(reason) {
+  return {
+    unitId: reason.unitId,
+    semanticType: reason.semanticType,
+    relationLabel: reason.relationLabel,
+    topicLabel: reason.topicLabel,
+    score: reason.score,
+    detailBullets: (reason.detailBullets || []).slice(0, 3)
+  };
+}
+
+function compactResult(result) {
+  return {
+    employeeName: result.employeeName,
+    score: result.score,
+    reasons: (result.reasons || []).map(compactReason),
+    quotes: (result.quotes || []).slice(0, 2).map((quote) => ({
+      text: quote.text,
+      channelName: quote.channelName,
+      authorName: quote.authorName
+    }))
+  };
+}
+
+function buildRerankPrompt(query, results) {
+  return `あなたは社員検索の再ランキング担当です。
+検索クエリに対して、候補社員が本当に近いかを根拠だけで判定してください。
+
+判定ラベル:
+- direct: 検索意図に直接合う
+- adjacent: 近いが主目的から少し外れる
+- weak: 関連はあるが候補として弱い
+- reject: 表示しない
+
+ルール:
+- 根拠にない推測はしない
+- 「QAエンジニア」のような職種検索では、AI、エンジニア、影響力だけの候補は reject または weak
+- 「ポケモン」のような趣味検索では、具体的な接点がある候補を direct
+- selectedReasonUnitIds は判定根拠に使ったunitIdだけを入れる
+- JSONだけを返す
+
+出力形式:
+{
+  "decisions": [
+    {
+      "employeeName": "社員名",
+      "intentFit": "direct",
+      "confidence": 0.9,
+      "reason": "短い理由",
+      "selectedReasonUnitIds": ["search-unit:..."]
+    }
+  ]
+}
+
+検索クエリ:
+${query}
+
+候補:
+${JSON.stringify(results.map(compactResult), null, 2)}`;
+}
+
+async function createGeminiReranker(options = {}) {
+  const apiKey = options.apiKey || process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error('GEMINI_API_KEY is required for gemini reranker. Use --reranker local-fixture for tests.');
+  }
+  const { GoogleGenerativeAI } = require('@google/generative-ai');
+  const modelName = options.model || process.env.GEMINI_RERANK_MODEL || 'gemini-2.0-flash';
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({
+    model: modelName,
+    generationConfig: {
+      temperature: 0,
+      responseMimeType: 'application/json'
+    }
+  });
+  return {
+    name: 'gemini',
+    model: modelName,
+    async rerank(query, results) {
+      const response = await model.generateContent(buildRerankPrompt(query, results));
+      return parseJsonText(response.response.text()).decisions || [];
+    }
+  };
+}
+
+function textIncludesAny(text, terms) {
+  const normalized = normalizeText(text);
+  return terms.some((term) => normalized.includes(normalizeText(term)));
+}
+
+function resultText(result) {
+  return [
+    result.employeeName,
+    ...(result.reasons || []).flatMap((reason) => [
+      reason.semanticType,
+      reason.relationLabel,
+      reason.topicLabel,
+      ...(reason.detailBullets || [])
+    ]),
+    ...(result.quotes || []).map((quote) => quote.text)
+  ].join(' ');
+}
+
+function firstMatchingReasonIds(result, terms) {
+  return (result.reasons || [])
+    .filter((reason) => textIncludesAny([
+      reason.relationLabel,
+      reason.topicLabel,
+      ...(reason.detailBullets || [])
+    ].join(' '), terms))
+    .map((reason) => reason.unitId)
+    .slice(0, 3);
+}
+
+function localDecision(query, result) {
+  const normalizedQuery = normalizeText(query);
+  const text = resultText(result);
+
+  if (textIncludesAny(normalizedQuery, ['ポケモン', 'ポケカ', 'pokemon', 'pokémon'])) {
+    const terms = ['ポケモン', 'ポケカ', 'pokemon', 'pokémon'];
+    const matchedIds = firstMatchingReasonIds(result, terms);
+    const matched = matchedIds.length > 0 || (result.quotes || []).some((quote) => textIncludesAny(quote.text, terms));
+    return {
+      employeeName: result.employeeName,
+      intentFit: matched ? 'direct' : 'reject',
+      confidence: matched ? 0.9 : 0.1,
+      reason: matched ? 'ポケモンまたはポケカへの具体的な接点がある' : 'ポケモン文脈の根拠がない',
+      selectedReasonUnitIds: matchedIds
+    };
+  }
+
+  if (textIncludesAny(normalizedQuery, ['qa', '品質保証', 'テスト', '検証'])) {
+    const directTerms = ['qa', '品質保証', 'qaエンジニア'];
+    const adjacentTerms = ['テスト', '総合テスト', 'テスト設計', '検証', '品質管理'];
+    const directIds = firstMatchingReasonIds(result, directTerms);
+    const adjacentIds = firstMatchingReasonIds(result, adjacentTerms);
+    const direct = directIds.length > 0;
+    const adjacent = adjacentIds.length > 0;
+    return {
+      employeeName: result.employeeName,
+      intentFit: direct ? 'direct' : adjacent ? 'adjacent' : 'reject',
+      confidence: direct ? 0.92 : adjacent ? 0.76 : 0.18,
+      reason: direct
+        ? 'QAまたは品質保証の根拠がある'
+        : adjacent
+          ? 'テストや検証の経験に近い根拠がある'
+          : 'QAやテストに直接つながる根拠が弱い',
+      selectedReasonUnitIds: direct ? directIds : adjacentIds
+    };
+  }
+
+  const queryTerms = tokenize(normalizedQuery).filter((term) => term.length >= 2);
+  const matched = queryTerms.some((term) => normalizeText(text).includes(term));
+  return {
+    employeeName: result.employeeName,
+    intentFit: matched ? 'direct' : 'weak',
+    confidence: matched ? 0.72 : 0.35,
+    reason: matched ? '検索語に対応する根拠がある' : 'ベクトル類似はあるが明示的な根拠は弱い',
+    selectedReasonUnitIds: firstMatchingReasonIds(result, queryTerms)
+  };
+}
+
+function createLocalFixtureReranker() {
+  return {
+    name: 'local-fixture',
+    model: 'local-rerank-rules-v1',
+    async rerank(query, results) {
+      return results.map((result) => localDecision(query, result));
+    }
+  };
+}
+
+async function createReranker(options = {}) {
+  const provider = options.provider || process.env.PROFILE_RERANK_PROVIDER || 'gemini';
+  if (provider === 'local-fixture') return createLocalFixtureReranker();
+  if (provider === 'gemini') return createGeminiReranker(options);
+  throw new Error(`Unknown reranker provider: ${provider}`);
+}
+
+function applyDecisions(results, decisions, options = {}) {
+  const includeAdjacent = options.includeAdjacent !== false;
+  const decisionByName = new Map(decisions.map((decision) => [decision.employeeName, decision]));
+  return results
+    .map((result) => {
+      const decision = decisionByName.get(result.employeeName);
+      if (!decision) return null;
+      const selectedIds = new Set(decision.selectedReasonUnitIds || []);
+      const selectedReasons = selectedIds.size > 0
+        ? result.reasons.filter((reason) => selectedIds.has(reason.unitId))
+        : result.reasons;
+      return {
+        ...result,
+        intentFit: decision.intentFit,
+        rerankConfidence: decision.confidence,
+        rerankReason: decision.reason,
+        reasons: selectedReasons.length > 0 ? selectedReasons : result.reasons
+      };
+    })
+    .filter(Boolean)
+    .filter((result) => result.intentFit === 'direct' || (includeAdjacent && result.intentFit === 'adjacent'))
+    .sort((a, b) => {
+      const rankDiff = (INTENT_RANK[b.intentFit] || 0) - (INTENT_RANK[a.intentFit] || 0);
+      if (rankDiff !== 0) return rankDiff;
+      return (b.rerankConfidence || 0) - (a.rerankConfidence || 0) || b.score - a.score;
+    });
+}
+
+async function rerankPeopleResults(query, results, reranker, options = {}) {
+  const candidateLimit = Number(options.candidateLimit || 12);
+  const candidates = results.slice(0, candidateLimit);
+  const decisions = await reranker.rerank(query, candidates);
+  return applyDecisions(candidates, decisions, options);
+}
+
+module.exports = {
+  applyDecisions,
+  buildRerankPrompt,
+  createReranker,
+  rerankPeopleResults
+};

--- a/scripts/test-people-finder-rerank.js
+++ b/scripts/test-people-finder-rerank.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const { buildProfileSearchIndex } = require('./build-profile-search-index');
+const { embedProfileSearchIndex } = require('./embed-profile-search-index');
+const { searchProfileVectors } = require('./people-finder-vector-search');
+const { createLocalFixtureProvider } = require('./profile-embedding-utils');
+const { createReranker, rerankPeopleResults } = require('./rerank-people-finder-results');
+
+async function main() {
+  const profileGraph = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/employee-profile-graph.jsonld'), 'utf8'));
+  const index = buildProfileSearchIndex(profileGraph, '2026-05-27T00:00:00.000Z');
+  const embeddingProvider = createLocalFixtureProvider({ dimensions: 1024 });
+  const embedded = await embedProfileSearchIndex(index, embeddingProvider, {
+    outputFile: path.join('/tmp', 'missing-profile-search-index.embedded.json')
+  });
+  const reranker = await createReranker({ provider: 'local-fixture' });
+
+  const qaVectorResults = await searchProfileVectors(embedded, 'QAエンジニア', embeddingProvider, {
+    threshold: 0.15,
+    topUnits: 100
+  });
+  assert(
+    qaVectorResults.some((result) => result.employeeName === '小松田真伍'),
+    'vector candidates should still contain adjacent/noisy engineer results before reranking'
+  );
+
+  const qaReranked = await rerankPeopleResults('QAエンジニア', qaVectorResults, reranker, {
+    candidateLimit: 12
+  });
+  const qaNames = qaReranked.map((result) => result.employeeName);
+  assert(qaNames.includes('開米 敦則'), 'rerank should keep direct QA result');
+  assert(qaNames.includes('上原基臣'), 'rerank should keep adjacent test experience result');
+  assert(!qaNames.includes('小松田真伍'), 'rerank should drop engineer-only results for QA query');
+  const kaimai = qaReranked.find((result) => result.employeeName === '開米 敦則');
+  assert.strictEqual(kaimai.intentFit, 'direct');
+  assert(kaimai.reasons.some((reason) => reason.relationLabel.includes('QAエンジニアリング')));
+
+  const pokemonVectorResults = await searchProfileVectors(embedded, 'ポケカが好きな人', embeddingProvider, {
+    threshold: 0.15,
+    topUnits: 80
+  });
+  const pokemonReranked = await rerankPeopleResults('ポケカが好きな人', pokemonVectorResults, reranker, {
+    candidateLimit: 10
+  });
+  const pokemonNames = pokemonReranked.map((result) => result.employeeName);
+  assert(pokemonNames.includes('小島遼祐'), 'rerank should keep concrete Pokemon card result');
+  assert(pokemonNames.includes('榎本詩織'), 'rerank should keep concrete Pokemon result');
+  assert(
+    pokemonReranked.every((result) => ['direct', 'adjacent'].includes(result.intentFit)),
+    'rerank should only return displayable intent fits'
+  );
+
+  console.log('people finder rerank OK');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要
ベクトル検索の上位候補に対して、検索意図に本当に合うかを再評価するAI再ランキング層を追加しました。

- `scripts/rerank-people-finder-results.js` を追加
  - Gemini reranker: `direct` / `adjacent` / `weak` / `reject` をJSONで返す
  - local-fixture reranker: APIキーなしのテスト用
- `scripts/people-finder-vector-search.js` に `--rerank` を追加
- `--direct-only` で `direct` だけ表示できるように追加
- `scripts/test-people-finder-rerank.js` を追加

## 使い方

Geminiで再ランキングする場合:

```bash
npm run search:profile-vector -- --query "QAエンジニア" --rerank
```

テスト用fixtureで再ランキングする場合:

```bash
npm run search:profile-vector -- \
  --provider local-fixture \
  --file /tmp/profile-search-index.embedded.json \
  --query "QAエンジニア" \
  --rerank \
  --reranker local-fixture
```

厳しく `direct` だけ表示する場合:

```bash
npm run search:profile-vector -- \
  --provider local-fixture \
  --file /tmp/profile-search-index.embedded.json \
  --query "QAエンジニア" \
  --rerank \
  --reranker local-fixture \
  --direct-only
```

## 確認したこと

local-fixtureでは、`QAエンジニア` のベクトル候補に混ざる `小松田真伍` を再ランキング後に落とし、以下を残すことを確認しています。

- 開米 敦則: `direct`
- 上原基臣: `adjacent`

`--direct-only` では開米さんのみ表示されることも確認しました。

## ブランチ・PR戦略

- base branch: `main`
- working branch: `codex/profile-rerank-20260527`
- PRサイズ: 再ランキング層とテストに限定
- split criteria: Slack Worker反映、実Gemini embedding済みindexの反映、Slack表示文変更は後続PR
- 次PR: Workerでベクトル検索 + 再ランキングを使うための実行経路を追加

## テスト

- `node --check scripts/rerank-people-finder-results.js`
- `node --check scripts/people-finder-vector-search.js`
- `node --check scripts/test-people-finder-rerank.js`
- `npm run test:people-finder-rerank`
- `npm run test:profile-vector-search`
- `npm run test:employee-profile-graph`
- `npm run test:people-finder`
- `git diff --check`

## 残リスク

- 実Gemini API呼び出しは未検証です。手元に `GEMINI_API_KEY` がないため、テストは `local-fixture` で行っています。
- local-fixtureは回帰テスト用で、実際の検索品質評価はGemini rerankerで確認が必要です。
- Slack App / Cloudflare Worker への反映はまだ含めていません。