### PR TITLE
メッセージ検索index生成workflowを追加する

### DIFF
--- a/.github/workflows/build-message-search-index.yml
+++ b/.github/workflows/build-message-search-index.yml
@@ -1,0 +1,43 @@
+name: Build Message Search Index
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-message-index:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Message Search Index
+        run: npm run build:message-search-index
+
+      - name: Embed Message Search Index
+        run: npm run embed:message-search-index
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Commit and Push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add data/message-search-index.json data/message-search-index.embedded.json
+          if git diff --staged --quiet; then
+            echo "No message search index changes to commit"
+          else
+            git commit -m "Auto: Update message search index"
+            git push
+          fi


### PR DESCRIPTION
## 概要
- Slack同期全体を待たずに `message-search-index` だけを生成できる手動workflowを追加しました。
- `npm run build:message-search-index` と `npm run embed:message-search-index` を実行し、生成された `data/message-search-index.json` と `data/message-search-index.embedded.json` をmainへcommitします。

## ブランチ・PR戦略
- base: `main`
- working branch: `codex/add-message-index-workflow-20260528`
- PRサイズ: workflow 1ファイルのみ。今回の運用補助に閉じています。
- 分割基準: 既存のSlack同期workflow高速化やknowledge graphのAI skip設定は別PRに分けます。
- PR作成タイミング: フル同期workflowがknowledge graph工程で長時間止まったため、message index生成だけを通すために作成。

## 検証
- `git diff --check`

## 残リスク
- 実embedding生成はmerge後にこのworkflowを手動実行して確認します。
