### PR TITLE
Gemini embeddingの503をリトライ対象にする

### DIFF
--- a/scripts/embed-profile-search-index.js
+++ b/scripts/embed-profile-search-index.js
@@ -113,7 +113,12 @@ async function embedWithRetry(provider, text, task, options = {}) {
 
 function isRetryableEmbeddingError(error) {
   const message = String(error?.message || error || '');
-  return message.includes('429') || message.includes('Too Many Requests') || message.includes('quota');
+  return message.includes('429')
+    || message.includes('503')
+    || message.includes('Too Many Requests')
+    || message.includes('UNAVAILABLE')
+    || message.includes('service is currently unavailable')
+    || message.includes('quota');
 }
 
 function sleep(ms) {


### PR DESCRIPTION
## 概要
- Gemini `embedContent` が一時的に 503 / UNAVAILABLE を返した場合も、既存のembedding retry処理で再試行するようにしました。
- `Build Message Search Index` workflowで `Gemini embedContent failed: 503` が出て即失敗したための修正です。

## ブランチ・PR戦略
- base: `main`
- working branch: `codex/retry-gemini-embedding-unavailable-20260528`
- PRサイズ: 1ファイル、retry条件のみ。
- 分割基準: checkpoint保存やembedding高速化は別PRに分けます。
- PR作成タイミング: workflow失敗原因の確認後。

## 検証
- `git diff --check`
- `npm run test:message-vector`

## 残リスク
- Gemini側の503が長時間続く場合は、既定の最大リトライ後に失敗します。
