### PR TITLE
TEAM.md生成処理を共通化

### DIFF
--- a/scripts/lib/team-doc.js
+++ b/scripts/lib/team-doc.js
@@ -1,0 +1,206 @@
+const fs = require('fs');
+const path = require('path');
+
+const TEAM_DOC_FILE = path.join(__dirname, '../../docs/TEAM.md');
+
+const JOB_MAP = {
+  Engineer: 'Engineer',
+  Designer: 'Designer',
+  Sales: 'Sales',
+  PM: 'PM',
+  Corporate: 'Corporate',
+  EM: 'Engineer',
+  QA: 'QA',
+  HR: 'HR',
+  '経営': '経営',
+  Executive: '経営',
+  Other: 'Other',
+};
+
+const MODE_CONFIG = {
+  issue: {
+    intro: '自動生成された組織図です。Issueによる更新が反映されます。',
+    includeRelatedResources: false,
+    includeOrgMapHeading: false,
+    sectionLabels: {
+      personality: '🛠 性格傾向 (Personality Traits)',
+      strengths: '💪 仕事スタイルと強み (Work Styles & Strengths)',
+      values: '💎 価値観とモチベーター (Values & Motivators)',
+      current: '📈 現在の状態 (Current State)',
+    },
+    traitLabels: {
+      openness: '開放性 (Openness)',
+      conscientiousness: '誠実性 (Conscientiousness)',
+      extraversion: '外向性 (Extraversion)',
+      agreeableness: '協調性 (Agreeableness)',
+      neuroticism: '神経症的傾向 (Neuroticism)',
+    },
+    personalitySummaryFallback: employee => employee.personality || '-',
+    personalityMissing: employee => `※Slack連携後に詳細な性格分析結果が表示されます。 (暫定性格: ${employee.personality || '-'})\n`,
+    strengthsMissing: employee => `※Slack連携後に詳細な強み分析が表示されます。 (既存スキル: ${employee.skills?.join(', ') || '-'})\n`,
+    valuesMissing: () => '※Slack連携後に詳細分析が表示されます。\n',
+    currentMissing: () => '※Slack連携後に表示されます。\n',
+    alumniPrefix: '\n',
+  },
+  slack: {
+    intro: '自動生成された組織図です。IssueおよびSlack連携による高度なAI分析結果が反映されます。',
+    includeRelatedResources: true,
+    includeOrgMapHeading: true,
+    sectionLabels: {
+      personality: '🛠 性格傾向',
+      strengths: '💪 仕事スタイルと強み',
+      values: '💎 価値観とモチベーター',
+      current: '📈 現在の状態',
+    },
+    traitLabels: {
+      openness: '開放性',
+      conscientiousness: '誠実性',
+      extraversion: '外向性',
+      agreeableness: '協調性',
+      neuroticism: '神経症的傾向',
+    },
+    personalitySummaryFallback: () => '-',
+    personalityMissing: () => 'データなし\n',
+    strengthsMissing: () => 'データなし\n',
+    valuesMissing: () => 'データなし\n',
+    currentMissing: () => 'データなし\n',
+    alumniPrefix: '',
+    logMessage: outputFile => `Regenerated ${outputFile} with detailed profiles.`,
+  },
+};
+
+function getConfig(mode = 'slack') {
+  return MODE_CONFIG[mode] || MODE_CONFIG.slack;
+}
+
+function buildTeamDoc(employees, options = {}) {
+  const config = getConfig(options.mode);
+  const activeEmployees = employees.filter(employee => employee.isActive !== false);
+  const archivedEmployees = employees.filter(employee => employee.isActive === false);
+  const jobs = [...new Set(activeEmployees.map(employee => employee.job))];
+
+  let md = '# チーム構成図\n\n';
+  md += `${config.intro}\n\n`;
+
+  if (config.includeRelatedResources) {
+    md += '### 📊 関連リソース\n';
+    md += '- [🌐 インタラクティブ・ナレッジグラフ (Web版)](https://saitekiinc-com.github.io/saiteki-employee-management/)\n';
+    md += '- [📝 ナレッジグラフ分析レポート (Markdown)](./KNOWLEDGE_GRAPH.md)\n\n';
+  }
+
+  if (config.includeOrgMapHeading) {
+    md += '### 組織マップ\n';
+  }
+
+  md += '```mermaid\n%%{init: {\'theme\': \'base\', \'themeVariables\': {\'primaryColor\': \'#F2EBE3\', \'primaryTextColor\': \'#5D574F\', \'primaryBorderColor\': \'#D9CFC1\', \'lineColor\': \'#BEB3A5\', \'secondaryColor\': \'#FAF9F6\', \'tertiaryColor\': \'#FDFCFB\', \'nodeBorder\': \'1px\'}}}%%\nmindmap\n  root((株式会社Saiteki))\n';
+  jobs.forEach(job => {
+    md += `    ${JOB_MAP[job] || job || 'Other'}\n`;
+    activeEmployees.filter(employee => employee.job === job).forEach(member => {
+      md += `      ${member.name.replace(/[()"']/g, '')}\n`;
+    });
+  });
+  md += '```\n\n';
+
+  md += '## 社員一覧サマリー\n\n| 名前 | 職種 | 性格傾向 (概略) | 現在の状態 |\n| --- | --- | --- | --- |\n';
+  activeEmployees.forEach(employee => {
+    const personality = employee.personality_traits?.summary || config.personalitySummaryFallback(employee);
+    const current = employee.current_state?.summary || '-';
+    md += `| [${employee.name}](#${encodeURIComponent(employee.name)}) | ${employee.job} | ${personality} | ${current} |\n`;
+  });
+  md += '\n---\n\n## 詳細プロフィール\n\n各社員の詳細な分析結果です。クリックして展開できます。\n\n';
+
+  activeEmployees.forEach(employee => {
+    md += `<div id="${employee.name}"></div>\n\n`;
+    md += `### ${employee.name} (${employee.job})\n\n`;
+    md += `> **総合サマリー**: ${employee.overall_summary || '-'}\n\n`;
+
+    md += `<details>\n<summary><b>${config.sectionLabels.personality}</b></summary>\n\n`;
+    if (employee.personality_traits) {
+      md += `**要約**: ${employee.personality_traits.summary}\n\n`;
+      md += '| 項目 | スコア | 根拠・エピソード |\n| --- | --- | --- |\n';
+      Object.entries(config.traitLabels).forEach(([traitKey, traitLabel]) => {
+        const data = employee.personality_traits[traitKey];
+        if (data) {
+          const safeEvidence = (data.evidence || '').replace(/\n/g, '<br>');
+          md += `| ${traitLabel} | ${data.score}/10 | ${safeEvidence} |\n`;
+        }
+      });
+    } else {
+      md += config.personalityMissing(employee);
+    }
+    md += '\n</details>\n\n';
+
+    md += `<details>\n<summary><b>${config.sectionLabels.strengths}</b></summary>\n\n`;
+    if (employee.work_styles_and_strengths) {
+      md += `**要約**: ${employee.work_styles_and_strengths.summary}\n\n`;
+      md += `**問題解決スタイル**: ${employee.work_styles_and_strengths.problem_solving_style || '-'}\n\n`;
+      md += `**主要な強み**: ${employee.work_styles_and_strengths.dominant_strengths?.join(', ') || '-'}\n\n`;
+      md += '**証拠エピソード**:\n';
+      employee.work_styles_and_strengths.evidence_episodes?.forEach(episode => {
+        md += `- ${episode}\n`;
+      });
+    } else {
+      md += config.strengthsMissing(employee);
+    }
+    md += '\n</details>\n\n';
+
+    md += `<details>\n<summary><b>${config.sectionLabels.values}</b></summary>\n\n`;
+    if (employee.values_and_motivators) {
+      md += `**要約**: ${employee.values_and_motivators.summary}\n\n`;
+      md += `**コアバリュー**: ${employee.values_and_motivators.core_values?.join(', ') || '-'}\n\n`;
+      md += `**モチベーショントリガー**: ${employee.values_and_motivators.motivation_triggers?.join(', ') || '-'}\n\n`;
+      md += '**証拠エピソード**:\n';
+      employee.values_and_motivators.evidence_episodes?.forEach(episode => {
+        md += `- ${episode}\n`;
+      });
+    } else {
+      md += config.valuesMissing(employee);
+    }
+    md += '\n</details>\n\n';
+
+    md += `<details>\n<summary><b>${config.sectionLabels.current}</b></summary>\n\n`;
+    if (employee.current_state) {
+      md += `**要約**: ${employee.current_state.summary}\n\n`;
+      md += `- **感情レベル**: ${employee.current_state.sentiment_level || '-'}\n`;
+      md += `- **業務負荷状況**: ${employee.current_state.workload_status || '-'}\n`;
+      md += `- **最近の関心トピック**: ${employee.current_state.recent_topics_of_interest?.join(', ') || '-'}\n`;
+    } else {
+      md += config.currentMissing(employee);
+    }
+    md += '\n</details>\n\n';
+
+    md += '---\n\n';
+  });
+
+  if (archivedEmployees.length > 0) {
+    md += `${config.alumniPrefix}## Alumni (OB/OG)\n\n| 名前 | 在籍時の職種 | 理由 |\n| --- | --- | --- |\n`;
+    archivedEmployees.forEach(employee => {
+      md += `| ${employee.name} | ${employee.job} | ${employee.archivedReason || '-'} |\n`;
+    });
+  }
+
+  return md;
+}
+
+function generateTeamDoc(employees, options = {}) {
+  const outputFile = options.outputFile || TEAM_DOC_FILE;
+  const md = buildTeamDoc(employees, options);
+  const docDir = path.dirname(outputFile);
+
+  if (!fs.existsSync(docDir)) {
+    fs.mkdirSync(docDir, { recursive: true });
+  }
+
+  fs.writeFileSync(outputFile, md);
+
+  const config = getConfig(options.mode);
+  if (config.logMessage) {
+    console.log(config.logMessage(outputFile));
+  }
+}
+
+module.exports = {
+  TEAM_DOC_FILE,
+  buildTeamDoc,
+  generateTeamDoc,
+};

--- a/scripts/process-issue.js
+++ b/scripts/process-issue.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 require('dotenv').config();
+const { generateTeamDoc } = require('./lib/team-doc');
 
 const DATA_FILE = path.join(__dirname, '../data/employees.json');
-const TEAM_DOC_FILE = path.join(__dirname, '../docs/TEAM.md');
 
 // メイン処理
 async function main() {
@@ -34,7 +34,7 @@ async function main() {
           fs.writeFileSync(DATA_FILE, JSON.stringify(currentEmployees, null, 2));
         }
 
-        generateTeamDoc(currentEmployees);
+        generateTeamDoc(currentEmployees, { mode: 'issue' });
         console.log('TEAM.md regenerated and data enriched.');
         return;
       } else {
@@ -80,7 +80,7 @@ async function main() {
   fs.writeFileSync(DATA_FILE, JSON.stringify(employees, null, 2));
 
   // ドキュメント生成
-  generateTeamDoc(employees);
+  generateTeamDoc(employees, { mode: 'issue' });
 }
 
 // Issue本文のパース
@@ -270,109 +270,6 @@ function deleteEmployee(employees, data) {
     employees[index].archivedReason = data.reason;
     employees[index].archivedAt = new Date().toISOString();
   }
-}
-
-function generateTeamDoc(employees) {
-  const activeEmployees = employees.filter(e => e.isActive !== false);
-  const archivedEmployees = employees.filter(e => e.isActive === false);
-  const jobs = [...new Set(activeEmployees.map(e => e.job))];
-
-  let md = '# チーム構成図\n\n自動生成された組織図です。Issueによる更新が反映されます。\n\n';
-  md += '```mermaid\n%%{init: {\'theme\': \'base\', \'themeVariables\': {\'primaryColor\': \'#F2EBE3\', \'primaryTextColor\': \'#5D574F\', \'primaryBorderColor\': \'#D9CFC1\', \'lineColor\': \'#BEB3A5\', \'secondaryColor\': \'#FAF9F6\', \'tertiaryColor\': \'#FDFCFB\', \'nodeBorder\': \'1px\'}}}%%\nmindmap\n  root((株式会社Saiteki))\n';
-
-  const jobMap = { 'Engineer': 'Engineer', 'Designer': 'Designer', 'Sales': 'Sales', 'PM': 'PM', 'Corporate': 'Corporate', 'EM': 'Engineer', 'QA': 'QA', 'HR': 'HR', '経営': '経営', 'Executive': '経営', 'Other': 'Other' };
-
-  jobs.forEach(job => {
-    md += `    ${jobMap[job] || job || 'Other'}\n`;
-    activeEmployees.filter(e => e.job === job).forEach(m => {
-      md += `      ${m.name.replace(/[()"']/g, '')}\n`;
-    });
-  });
-  md += '```\n\n';
-  // 2. Summary Table
-  md += '## 社員一覧サマリー\n\n| 名前 | 職種 | 性格傾向 (概略) | 現在の状態 |\n| --- | --- | --- | --- |\n';
-  activeEmployees.forEach(e => {
-    const personality = e.personality_traits?.summary || (e.personality || '-');
-    const current = e.current_state?.summary || '-';
-    md += `| [${e.name}](#${encodeURIComponent(e.name)}) | ${e.job} | ${personality} | ${current} |\n`;
-  });
-  md += '\n---\n\n## 詳細プロフィール\n\n各社員の詳細な分析結果です。クリックして展開できます。\n\n';
-
-  // 3. Detailed Profiles
-  activeEmployees.forEach(e => {
-    md += `<div id="${e.name}"></div>\n\n`;
-    md += `### ${e.name} (${e.job})\n\n`;
-    md += `> **総合サマリー**: ${e.overall_summary || '-'}\n\n`;
-
-    md += '<details>\n<summary><b>🛠 性格傾向 (Personality Traits)</b></summary>\n\n';
-    if (e.personality_traits) {
-      md += `**要約**: ${e.personality_traits.summary}\n\n`;
-      md += '| 項目 | スコア | 根拠・エピソード |\n| --- | --- | --- |\n';
-      const traits = {
-        openness: '開放性 (Openness)',
-        conscientiousness: '誠実性 (Conscientiousness)',
-        extraversion: '外向性 (Extraversion)',
-        agreeableness: '協調性 (Agreeableness)',
-        neuroticism: '神経症的傾向 (Neuroticism)'
-      };
-      Object.keys(traits).forEach(t => {
-        const data = e.personality_traits[t];
-        if (data) {
-          const safeEvidence = (data.evidence || '').replace(/\n/g, '<br>');
-          md += `| ${traits[t]} | ${data.score}/10 | ${safeEvidence} |\n`;
-        }
-      });
-    } else {
-      md += `※Slack連携後に詳細な性格分析結果が表示されます。 (暫定性格: ${e.personality || '-'})\n`;
-    }
-    md += '\n</details>\n\n';
-
-    md += '<details>\n<summary><b>💪 仕事スタイルと強み (Work Styles & Strengths)</b></summary>\n\n';
-    if (e.work_styles_and_strengths) {
-      md += `**要約**: ${e.work_styles_and_strengths.summary}\n\n`;
-      md += `**問題解決スタイル**: ${e.work_styles_and_strengths.problem_solving_style || '-'}\n\n`;
-      md += `**主要な強み**: ${e.work_styles_and_strengths.dominant_strengths?.join(', ') || '-'}\n\n`;
-      md += '**証拠エピソード**:\n';
-      e.work_styles_and_strengths.evidence_episodes?.forEach(ep => md += `- ${ep}\n`);
-    } else {
-      md += `※Slack連携後に詳細な強み分析が表示されます。 (既存スキル: ${e.skills?.join(', ') || '-'})\n`;
-    }
-    md += '\n</details>\n\n';
-
-    md += '<details>\n<summary><b>💎 価値観とモチベーター (Values & Motivators)</b></summary>\n\n';
-    if (e.values_and_motivators) {
-      md += `**要約**: ${e.values_and_motivators.summary}\n\n`;
-      md += `**コアバリュー**: ${e.values_and_motivators.core_values?.join(', ') || '-'}\n\n`;
-      md += `**モチベーショントリガー**: ${e.values_and_motivators.motivation_triggers?.join(', ') || '-'}\n\n`;
-      md += '**証拠エピソード**:\n';
-      e.values_and_motivators.evidence_episodes?.forEach(ep => md += `- ${ep}\n`);
-    } else {
-      md += '※Slack連携後に詳細分析が表示されます。\n';
-    }
-    md += '\n</details>\n\n';
-
-    md += '<details>\n<summary><b>📈 現在の状態 (Current State)</b></summary>\n\n';
-    if (e.current_state) {
-      md += `**要約**: ${e.current_state.summary}\n\n`;
-      md += `- **感情レベル**: ${e.current_state.sentiment_level || '-'}\n`;
-      md += `- **業務負荷状況**: ${e.current_state.workload_status || '-'}\n`;
-      md += `- **最近の関心トピック**: ${e.current_state.recent_topics_of_interest?.join(', ') || '-'}\n`;
-    } else {
-      md += '※Slack連携後に表示されます。\n';
-    }
-    md += '\n</details>\n\n';
-
-    md += '---\n\n';
-  });
-
-  if (archivedEmployees.length > 0) {
-    md += '\n## Alumni (OB/OG)\n\n| 名前 | 在籍時の職種 | 理由 |\n| --- | --- | --- |\n';
-    archivedEmployees.forEach(e => md += `| ${e.name} | ${e.job} | ${e.archivedReason || '-'} |\n`);
-  }
-
-  const docDir = path.dirname(TEAM_DOC_FILE);
-  if (!fs.existsSync(docDir)) fs.mkdirSync(docDir, { recursive: true });
-  fs.writeFileSync(TEAM_DOC_FILE, md);
 }
 
 main().catch(console.error);

--- a/scripts/sync-slack.js
+++ b/scripts/sync-slack.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 require('dotenv').config();
 const { mergeSlackMessages, readJsonl, writeJsonl } = require('./build-search-facets');
+const { generateTeamDoc } = require('./lib/team-doc');
 
 const DATA_FILE = path.join(__dirname, '../data/employees.json');
 const BACKUP_FILE = path.join(__dirname, '../data/employees.backup.json');
@@ -171,7 +172,7 @@ async function main() {
         console.log(`Saved ${updatedCount} profile updates and ${discoveredCount} new employees to ${DATA_FILE}.`);
 
         // Regenerate TEAM.md with the new data format
-        generateTeamDoc(employees);
+        generateTeamDoc(employees, { mode: 'slack' });
     } else {
         console.log('No updates performed.');
     }
@@ -447,117 +448,6 @@ async function analyzeSlackActivityAdvanced(name, messages, existingProfile = nu
         console.error(`AI analysis failed for ${name}:`, error.message);
         return { ai_error: true };
     }
-}
-
-const TEAM_DOC_FILE = path.join(__dirname, '../docs/TEAM.md');
-
-function generateTeamDoc(employees) {
-    const activeEmployees = employees.filter(e => e.isActive !== false);
-    const archivedEmployees = employees.filter(e => e.isActive === false);
-    const jobs = [...new Set(activeEmployees.map(e => e.job))];
-
-    let md = '# チーム構成図\n\n自動生成された組織図です。IssueおよびSlack連携による高度なAI分析結果が反映されます。\n\n';
-    md += '### 📊 関連リソース\n';
-    md += '- [🌐 インタラクティブ・ナレッジグラフ (Web版)](https://saitekiinc-com.github.io/saiteki-employee-management/)\n';
-    md += '- [📝 ナレッジグラフ分析レポート (Markdown)](./KNOWLEDGE_GRAPH.md)\n\n';
-
-    // 1. Mermaid Map
-    md += '### 組織マップ\n';
-    md += '```mermaid\n%%{init: {\'theme\': \'base\', \'themeVariables\': {\'primaryColor\': \'#F2EBE3\', \'primaryTextColor\': \'#5D574F\', \'primaryBorderColor\': \'#D9CFC1\', \'lineColor\': \'#BEB3A5\', \'secondaryColor\': \'#FAF9F6\', \'tertiaryColor\': \'#FDFCFB\', \'nodeBorder\': \'1px\'}}}%%\nmindmap\n  root((株式会社Saiteki))\n';
-    const jobMap = { 'Engineer': 'Engineer', 'Designer': 'Designer', 'Sales': 'Sales', 'PM': 'PM', 'Corporate': 'Corporate', 'EM': 'Engineer', 'QA': 'QA', 'HR': 'HR', '経営': '経営', 'Executive': '経営', 'Other': 'Other' };
-    jobs.forEach(job => {
-        md += `    ${jobMap[job] || job || 'Other'}\n`;
-        activeEmployees.filter(e => e.job === job).forEach(m => {
-            md += `      ${m.name.replace(/[()"']/g, '')}\n`;
-        });
-    });
-    md += '```\n\n';
-
-    // 2. Summary Table
-    md += '## 社員一覧サマリー\n\n| 名前 | 職種 | 性格傾向 (概略) | 現在の状態 |\n| --- | --- | --- | --- |\n';
-    activeEmployees.forEach(e => {
-        const personality = e.personality_traits?.summary || '-';
-        const current = e.current_state?.summary || '-';
-        md += `| [${e.name}](#${encodeURIComponent(e.name)}) | ${e.job} | ${personality} | ${current} |\n`;
-    });
-    md += '\n---\n\n## 詳細プロフィール\n\n各社員の詳細な分析結果です。クリックして展開できます。\n\n';
-
-    // 3. Detailed Profiles
-    activeEmployees.forEach(e => {
-        md += `<div id="${e.name}"></div>\n\n`;
-        md += `### ${e.name} (${e.job})\n\n`;
-        md += `> **総合サマリー**: ${e.overall_summary || '-'}\n\n`;
-
-        md += '<details>\n<summary><b>🛠 性格傾向</b></summary>\n\n';
-        if (e.personality_traits) {
-            md += `**要約**: ${e.personality_traits.summary}\n\n`;
-            md += '| 項目 | スコア | 根拠・エピソード |\n| --- | --- | --- |\n';
-            const traits = {
-                openness: '開放性',
-                conscientiousness: '誠実性',
-                extraversion: '外向性',
-                agreeableness: '協調性',
-                neuroticism: '神経症的傾向'
-            };
-            Object.keys(traits).forEach(t => {
-                const data = e.personality_traits[t];
-                if (data) {
-                    const safeEvidence = (data.evidence || '').replace(/\n/g, '<br>');
-                    md += `| ${traits[t]} | ${data.score}/10 | ${safeEvidence} |\n`;
-                }
-            });
-        } else {
-            md += 'データなし\n';
-        }
-        md += '\n</details>\n\n';
-
-        md += '<details>\n<summary><b>💪 仕事スタイルと強み</b></summary>\n\n';
-        if (e.work_styles_and_strengths) {
-            md += `**要約**: ${e.work_styles_and_strengths.summary}\n\n`;
-            md += `**問題解決スタイル**: ${e.work_styles_and_strengths.problem_solving_style || '-'}\n\n`;
-            md += `**主要な強み**: ${e.work_styles_and_strengths.dominant_strengths?.join(', ') || '-'}\n\n`;
-            md += '**証拠エピソード**:\n';
-            e.work_styles_and_strengths.evidence_episodes?.forEach(ep => md += `- ${ep}\n`);
-        } else {
-            md += 'データなし\n';
-        }
-        md += '\n</details>\n\n';
-
-        md += '<details>\n<summary><b>💎 価値観とモチベーター</b></summary>\n\n';
-        if (e.values_and_motivators) {
-            md += `**要約**: ${e.values_and_motivators.summary}\n\n`;
-            md += `**コアバリュー**: ${e.values_and_motivators.core_values?.join(', ') || '-'}\n\n`;
-            md += `**モチベーショントリガー**: ${e.values_and_motivators.motivation_triggers?.join(', ') || '-'}\n\n`;
-            md += '**証拠エピソード**:\n';
-            e.values_and_motivators.evidence_episodes?.forEach(ep => md += `- ${ep}\n`);
-        } else {
-            md += 'データなし\n';
-        }
-        md += '\n</details>\n\n';
-
-        md += '<details>\n<summary><b>📈 現在の状態</b></summary>\n\n';
-        if (e.current_state) {
-            md += `**要約**: ${e.current_state.summary}\n\n`;
-            md += `- **感情レベル**: ${e.current_state.sentiment_level || '-'}\n`;
-            md += `- **業務負荷状況**: ${e.current_state.workload_status || '-'}\n`;
-            md += `- **最近の関心トピック**: ${e.current_state.recent_topics_of_interest?.join(', ') || '-'}\n`;
-        } else {
-            md += 'データなし\n';
-        }
-        md += '\n</details>\n\n';
-
-        md += '---\n\n';
-    });
-
-    if (archivedEmployees.length > 0) {
-        md += '## Alumni (OB/OG)\n\n| 名前 | 在籍時の職種 | 理由 |\n| --- | --- | --- |\n';
-        archivedEmployees.forEach(e => md += `| ${e.name} | ${e.job} | ${e.archivedReason || '-'} |\n`);
-    }
-
-    const docDir = path.dirname(TEAM_DOC_FILE);
-    if (!fs.existsSync(docDir)) fs.mkdirSync(docDir, { recursive: true });
-    fs.writeFileSync(TEAM_DOC_FILE, md);
-    console.log(`Regenerated ${TEAM_DOC_FILE} with detailed profiles.`);
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## 概要
- Issue更新とSlack同期に重複していた TEAM.md 生成処理を `scripts/lib/team-doc.js` に共通化
- 呼び出し元ごとの差分は `mode: 'issue'` / `mode: 'slack'` で保持
- 最新の `origin/main` ベースに当て直し、Slack同期側の現行変更を維持

## テスト
- `node --check scripts/lib/team-doc.js && node --check scripts/process-issue.js && node --check scripts/sync-slack.js`
- 旧 `origin/main` の生成関数と新 `buildTeamDoc` の出力を実データで比較し、Issue/Slack両モードが文字列一致することを確認

## ブランチ・PR戦略
- base: `main`（最新 `origin/main`）
- working branch: `refactor/team-doc-generator`
- PRサイズ: 3ファイル、211追加/218削除。移動・共通化が中心で、実質的な振る舞い変更なし
- split criteria: 今回は TEAM.md 生成処理の共通化に限定。AI分析、Slack取得、検索index生成は別PR扱い
- PR作成タイミング: 実装・構文チェック・旧出力比較後に作成

## 残リスク
- 生成ロジックの責務が共通モジュールに集まったため、今後表示差分を増やす場合は mode 設計の見直しが必要