### PR TITLE
Gemini embeddingを設定次元に切り詰める

### DIFF
--- a/scripts/profile-embedding-utils.js
+++ b/scripts/profile-embedding-utils.js
@@ -82,6 +82,11 @@ function normalizeVector(vector) {
   return vector.map((value) => Number((value / norm).toFixed(8)));
 }
 
+function fitVectorDimensions(vector, dimensions) {
+  if (!dimensions || !Array.isArray(vector) || vector.length <= dimensions) return vector;
+  return vector.slice(0, dimensions);
+}
+
 function localFixtureEmbedding(text, dimensions = DEFAULT_LOCAL_DIMENSIONS) {
   const vector = Array(dimensions).fill(0);
   for (const token of tokenize(text)) {
@@ -165,7 +170,7 @@ async function createEmbeddingProvider(options = {}) {
       if (!Array.isArray(data.embedding?.values)) {
         throw new Error('Gemini embedding response did not include embedding.values.');
       }
-      return data.embedding.values;
+      return fitVectorDimensions(data.embedding.values, dimensions);
     }
   };
 }
@@ -179,6 +184,7 @@ module.exports = {
   cosineSimilarity,
   createEmbeddingProvider,
   createLocalFixtureProvider,
+  fitVectorDimensions,
   localFixtureEmbedding,
   normalizeText,
   stripQueryHelpers,

--- a/scripts/test-message-vector-search.js
+++ b/scripts/test-message-vector-search.js
@@ -6,7 +6,7 @@ const path = require('path');
 const { buildMessageSearchIndex } = require('./build-message-search-index');
 const { embedProfileSearchIndex } = require('./embed-profile-search-index');
 const { searchProfileVectors } = require('./people-finder-vector-search');
-const { createLocalFixtureProvider } = require('./profile-embedding-utils');
+const { createLocalFixtureProvider, fitVectorDimensions } = require('./profile-embedding-utils');
 const { createReranker, rerankPeopleResults } = require('./rerank-people-finder-results');
 
 async function main() {
@@ -24,6 +24,7 @@ async function main() {
   assert(units.every((unit) => unit.quotes?.[0]?.text), 'message units should carry display quotes');
   assert(!units.some((unit) => unit.searchText.includes('チャンネルに参加しました')), 'system join messages should be excluded');
   assert(!units.some((unit) => unit.searchText.includes('チャットコピペ')), 'pasted chat transcripts should not be attributed to the poster');
+  assert.deepStrictEqual(fitVectorDimensions([1, 2, 3, 4], 2), [1, 2], 'oversized embeddings should be trimmed to configured dimensions');
 
   const provider = createLocalFixtureProvider({ dimensions: 1024 });
   const embedded = await embedProfileSearchIndex(index, provider, {

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -683,7 +683,12 @@ async function embedQuery(env, text, indexModel, indexDimensions = 0) {
   if (!Array.isArray(values)) {
     throw new Error('Gemini embedding response did not include embedding.values.');
   }
-  return values;
+  return fitVectorDimensions(values, dimensions);
+}
+
+function fitVectorDimensions(vector, dimensions) {
+  if (!dimensions || !Array.isArray(vector) || vector.length <= dimensions) return vector;
+  return vector.slice(0, dimensions);
 }
 
 async function rerankVectorResults(env, query, results, options = {}) {


### PR DESCRIPTION
## 概要
- Gemini APIが `outputDimensionality: 768` より大きいvectorを返した場合でも、生成スクリプト側で設定次元に切り詰めるようにしました。
- Worker側のクエリembeddingも、indexの次元に合わせて切り詰めます。
- message-search-index が55MB/3072次元になり、Workerで読み込み失敗して既存検索へ退避している可能性が高いための修正です。

## ブランチ・PR戦略
- base: `main`
- working branch: `codex/trim-gemini-embeddings-20260528`
- PRサイズ: 3ファイル、15行追加/3行削除。embedding次元合わせだけに限定。
- 分割基準: index圧縮形式や分割読み込みは別PR。
- PR作成タイミング: 本番で0件が続き、生成済みmessage indexの実vectorが3072次元だったことを確認した後。

## 検証
- `git diff --check`
- `npm run test:message-vector`
- `npm run test:profile-vector-search`
- `cd workers/slack-people-finder && npx wrangler deploy --dry-run`

## 残リスク
- 既存の巨大な `data/message-search-index.embedded.json` は、このPR merge後にworkflowで再生成する必要があります。
