### PR TITLE
Slack社員検索で発言本文一致を候補化に反映

### DIFF
--- a/scripts/people-finder-vector-search.js
+++ b/scripts/people-finder-vector-search.js
@@ -101,15 +101,27 @@ function dedupeQuotes(quotes) {
 }
 
 function lexicalLabelBoost(unit, queryText) {
-  const labelText = normalizeText([
+  const textParts = [
     unit.relationLabel,
     unit.topicLabel,
     ...(unit.topicAliases || [])
-  ].filter(Boolean).join(' '));
+  ];
+
+  if (unit.semanticType === 'slack_message') {
+    textParts.push(
+      unit.searchText,
+      ...(unit.detailBullets || []),
+      ...(unit.quotes || []).map((quote) => quote.text)
+    );
+  }
+
+  const labelText = normalizeText(textParts.filter(Boolean).join(' '));
   if (!labelText) return 0;
   const terms = tokenize(queryText).filter((term) => term.length >= 2);
   const matched = terms.filter((term) => labelText.includes(term)).length;
-  return Math.min(matched * 0.06, 0.18);
+  const weight = unit.semanticType === 'slack_message' ? 0.09 : 0.06;
+  const cap = unit.semanticType === 'slack_message' ? 0.24 : 0.18;
+  return Math.min(matched * weight, cap);
 }
 
 async function searchProfileVectors(index, query, provider, options = {}) {

--- a/scripts/test-message-vector-search.js
+++ b/scripts/test-message-vector-search.js
@@ -60,6 +60,32 @@ async function main() {
     'security results should expose concrete security messages'
   );
 
+  const lexicalOnlyIndex = {
+    '@graph': [
+      {
+        '@id': 'search-message:lexical-pokemon',
+        personName: '本文一致 太郎',
+        semanticType: 'slack_message',
+        relationLabel: 'Slack発言: 雑談',
+        topicLabel: '雑談',
+        searchText: '休日はポケモンのゲームとポケカをしています',
+        detailBullets: ['休日はポケモンのゲームとポケカをしています'],
+        quotes: [{ text: '休日はポケモンのゲームとポケカをしています' }],
+        embedding: { vector: [0, 1] }
+      }
+    ]
+  };
+  const orthogonalProvider = {
+    async embed() {
+      return [1, 0];
+    }
+  };
+  const lexicalOnly = await searchProfileVectors(lexicalOnlyIndex, 'ポケモン', orthogonalProvider, {
+    threshold: 0.12,
+    topUnits: 10
+  });
+  assert.strictEqual(lexicalOnly[0]?.employeeName, '本文一致 太郎', 'message text matches should survive even when vector similarity is weak');
+
   console.log('message vector search OK');
 }
 

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -610,15 +610,27 @@ function firstVectorDimensions(index) {
 }
 
 function lexicalLabelBoost(unit, queryText) {
-  const labelText = normalizeText([
+  const textParts = [
     unit.relationLabel,
     unit.topicLabel,
     ...(unit.topicAliases || [])
-  ].filter(Boolean).join(' '));
+  ];
+
+  if (unit.semanticType === 'slack_message') {
+    textParts.push(
+      unit.searchText,
+      ...(unit.detailBullets || []),
+      ...(unit.quotes || []).map((quote) => quote.text)
+    );
+  }
+
+  const labelText = normalizeText(textParts.filter(Boolean).join(' '));
   if (!labelText) return 0;
   const terms = tokenize(queryText).filter((term) => term.length >= 2);
   const matched = terms.filter((term) => labelText.includes(term)).length;
-  return Math.min(matched * 0.06, 0.18);
+  const weight = unit.semanticType === 'slack_message' ? 0.09 : 0.06;
+  const cap = unit.semanticType === 'slack_message' ? 0.24 : 0.18;
+  return Math.min(matched * weight, cap);
 }
 
 function aggregateVectorUnits(scoredUnits, threshold) {


### PR DESCRIPTION
## 概要
- Slackメッセージ検索の lexical boost 対象に発言本文、詳細メモ、引用文を追加
- 発言本文に検索語が明示されている場合、ベクトル類似が弱くても候補から落ちにくくする
- ポケモンの本文一致ケースをテストに追加

## ブランチ・PR戦略
- base: main
- working branch: codex/boost-message-lexical-search-20260528
- PR size budget: 300行以内（今回 3ファイル / +56 -6）
- split criteria: インデックス生成やデプロイ設定変更は別PR扱い
- PR creation timing: 実装・テスト・wrangler dry-run 後に作成

## 確認
- npm run test:message-vector
- npm run test:profile-vector-search
- git diff --check
- cd workers/slack-people-finder && npx wrangler deploy --dry-run

## リスク
- 本文の語一致補正により、完全な意味一致ではない発言も候補化されやすくなる可能性があります。ただし Slackメッセージ単位に限定し、rerank で direct/adjacent に絞ります。