### PR TITLE
Slack未登録の発言者もメッセージ検索に含める

### DIFF
--- a/scripts/build-message-search-index.js
+++ b/scripts/build-message-search-index.js
@@ -43,6 +43,19 @@ function employeeBySlackId(employees) {
   return byId;
 }
 
+function messageAuthor(message, employee) {
+  const name = cleanText(employee?.name || message.userRealName || message.userName || '', 120);
+  if (!name) return null;
+  return {
+    person: employee ? `person:${employee.name}` : `slack-user:${message.user}`,
+    personName: name,
+    slackIds: employee
+      ? [employee.slack_id, employee.slack_id_2].filter(Boolean)
+      : [message.user].filter(Boolean),
+    job: employee?.job || ''
+  };
+}
+
 function isSearchableMessage(message) {
   const text = cleanText(message.text || message.rawText || '');
   if (!message.id || !message.user || !text) return false;
@@ -69,7 +82,7 @@ function buildSearchText(message, employee) {
   return [
     message.text || message.rawText || '',
     message.channelName || '',
-    employee.job || ''
+    employee?.job || ''
   ].map((item) => cleanText(item, 1200)).filter(Boolean).join('\n');
 }
 
@@ -80,16 +93,17 @@ function buildMessageSearchIndex({ employees, messages, generatedAt = new Date()
   for (const message of messages) {
     if (!isSearchableMessage(message)) continue;
     const employee = bySlackId.get(message.user);
-    if (!employee) continue;
+    const author = messageAuthor(message, employee);
+    if (!author) continue;
 
     const quote = messageQuote(message);
     const text = cleanText(message.text || message.rawText || '', 500);
     units.push({
       '@id': `search-message:${message.id}`,
       '@type': 'saiteki:MessageSearchUnit',
-      person: `person:${employee.name}`,
-      personName: employee.name,
-      slackIds: [employee.slack_id, employee.slack_id_2].filter(Boolean),
+      person: author.person,
+      personName: author.personName,
+      slackIds: author.slackIds,
       message: quote.messageId,
       semanticType: 'slack_message',
       category: 'message',
@@ -101,7 +115,7 @@ function buildMessageSearchIndex({ employees, messages, generatedAt = new Date()
       timestamp: message.timestamp || '',
       detailBullets: [text],
       quotes: [quote],
-      searchText: buildSearchText(message, employee)
+      searchText: buildSearchText(message, author)
     });
   }
 
@@ -136,5 +150,6 @@ if (require.main === module) {
 
 module.exports = {
   buildMessageSearchIndex,
+  messageAuthor,
   writeMessageSearchIndex
 };

--- a/scripts/test-message-vector-search.js
+++ b/scripts/test-message-vector-search.js
@@ -25,6 +25,10 @@ async function main() {
   assert(!units.some((unit) => unit.searchText.includes('チャンネルに参加しました')), 'system join messages should be excluded');
   assert(!units.some((unit) => unit.searchText.includes('チャットコピペ')), 'pasted chat transcripts should not be attributed to the poster');
   assert.deepStrictEqual(fitVectorDimensions([1, 2, 3, 4], 2), [1, 2], 'oversized embeddings should be trimmed to configured dimensions');
+  assert(
+    units.some((unit) => unit.personName === '三本木拓磨' && unit.searchText.includes('ポケモン')),
+    'message index should include named Slack authors even before they exist in employees.json'
+  );
 
   const provider = createLocalFixtureProvider({ dimensions: 1024 });
   const embedded = await embedProfileSearchIndex(index, provider, {

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -580,10 +580,15 @@ async function searchVectorIndex(env, index, query, options = {}) {
     return results;
   }
 
-  return rerankVectorResults(env, query, results, {
-    candidateLimit: env.PEOPLE_FINDER_RERANK_CANDIDATES,
-    includeAdjacent: env.PEOPLE_FINDER_DIRECT_ONLY !== 'true'
-  });
+  try {
+    return await rerankVectorResults(env, query, results, {
+      candidateLimit: env.PEOPLE_FINDER_RERANK_CANDIDATES,
+      includeAdjacent: env.PEOPLE_FINDER_DIRECT_ONLY !== 'true'
+    });
+  } catch (error) {
+    console.error('Vector people rerank failed; returning vector results', error);
+    return results;
+  }
 }
 
 function ensureEmbeddedIndex(index) {


### PR DESCRIPTION
## 概要
- employees.json に未登録でも、Slackメッセージの userRealName/userName と user id から message search unit を生成
- 三本木拓磨さんのような入社予定者・未登録ユーザーの自己紹介も、発言ベースのベクトル検索対象に含める
- Gemini rerank が失敗した場合でも、message vector の候補結果は返すようにして facet/profile への過剰フォールバックを避ける

## ブランチ・PR戦略
- base: main
- working branch: codex/include-unregistered-message-authors-20260528
- PR size budget: 300行以内（今回 3ファイル / +34 -10）
- split criteria: 埋め込み済み index の再生成はマージ後に GitHub Actions で実施
- PR creation timing: 実装・ローカル生成確認・テスト・wrangler dry-run 後

## 確認
- npm run build:message-search-index で三本木拓磨さんの自己紹介を含む 3 件の発言ユニット生成を確認
- npm run test:message-vector
- npm run test:profile-vector-search
- git diff --check
- cd workers/slack-people-finder && npx wrangler deploy --dry-run

## リスク
- 社員マスタ未登録のSlack発言者も表示対象になるため、厳密な「社員」だけに閉じたい場合は別途フィルタが必要です。ただし今回の検索設計では、自己紹介投稿の発言者を拾う方が意図に合います。