### PR TITLE
社員検索の根拠メッセージをGitHub Pagesリンクにする

### DIFF
--- a/docs/slack-export/index.html
+++ b/docs/slack-export/index.html
@@ -172,6 +172,10 @@
   .message.thread-context {
     background: #fbfcfd;
   }
+  .message.target {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.16);
+  }
   .message-head {
     display: flex;
     gap: 8px;
@@ -262,14 +266,42 @@
 <script src="./slack-export-data.js"></script>
 <script>
 const data = window.SLACK_EXPORT_DATA;
+
+function normalizeMessageId(value) {
+  return String(value || '').replace(/^message:/, '').trim();
+}
+
+function locationMessageId() {
+  const params = new URLSearchParams(window.location.search);
+  const queryValue = params.get('message') || params.get('messageId');
+  if (queryValue) return normalizeMessageId(queryValue);
+
+  const hash = decodeURIComponent(window.location.hash.replace(/^#/, ''));
+  if (hash.startsWith('message=')) return normalizeMessageId(hash.slice('message='.length));
+  if (hash.startsWith('message:') || hash.startsWith('primary:')) return normalizeMessageId(hash);
+  return '';
+}
+
+function channelIdForMessage(messageId) {
+  const normalized = normalizeMessageId(messageId);
+  if (!normalized) return '';
+  for (const channel of data.channels || []) {
+    if ((channel.messages || []).some(message => normalizeMessageId(message.id) === normalized)) return channel.id;
+  }
+  return '';
+}
+
+const initialMessageId = locationMessageId();
 const state = {
-  channelId: data.channels[0]?.id || '',
+  channelId: channelIdForMessage(initialMessageId) || data.channels[0]?.id || '',
   channelSearch: '',
   messageSearch: '',
   dateFrom: '',
   dateTo: '',
-  systemMode: 'all'
+  systemMode: 'all',
+  targetMessageId: initialMessageId
 };
+let hasScrolledToTarget = false;
 
 const els = {
   exportMeta: document.getElementById('exportMeta'),
@@ -394,6 +426,10 @@ function renderMessages() {
     ? messages.length.toLocaleString() + ' / ' + channel.messageCount.toLocaleString() + ' messages, ' + (channel.firstDate || '-') + ' - ' + (channel.lastDate || '-')
     : '';
   els.messages.innerHTML = sections.length ? sections.map(renderSection).join('') : '<div class="empty">該当するメッセージはありません。</div>';
+  if (state.targetMessageId && !hasScrolledToTarget) {
+    hasScrolledToTarget = true;
+    window.requestAnimationFrame(scrollToTargetMessage);
+  }
 }
 
 function renderSection(section) {
@@ -418,8 +454,9 @@ function renderMessage(message, options) {
   const classNames = ['message'];
   if (message.subtype) classNames.push('system');
   if (opts.isContext) classNames.push('thread-context');
+  if (normalizeMessageId(message.id) === state.targetMessageId) classNames.push('target');
   return (
-    '<article class="' + classNames.join(' ') + '">' +
+    '<article id="' + escapeHtml(messageElementId(message.id)) + '" class="' + classNames.join(' ') + '">' +
       '<div class="message-head">' +
         '<span class="author">' + escapeHtml(message.userName) + '</span>' +
         '<span class="time">' + escapeHtml(formatDateTime(message.timestamp)) + '</span>' +
@@ -430,6 +467,15 @@ function renderMessage(message, options) {
       '<div class="text">' + escapeHtml(message.text || message.rawText || '(no text)') + '</div>' +
     '</article>'
   );
+}
+
+function messageElementId(messageId) {
+  return 'message-' + normalizeMessageId(messageId);
+}
+
+function scrollToTargetMessage() {
+  const element = document.getElementById(messageElementId(state.targetMessageId));
+  if (element) element.scrollIntoView({ block: 'center' });
 }
 
 function render() {

--- a/scripts/build-slack-export-pages.js
+++ b/scripts/build-slack-export-pages.js
@@ -336,6 +336,10 @@ function viewerHtml() {
   .message.thread-context {
     background: #fbfcfd;
   }
+  .message.target {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.16);
+  }
   .message-head {
     display: flex;
     gap: 8px;
@@ -426,14 +430,42 @@ function viewerHtml() {
 <script src="./slack-export-data.js"></script>
 <script>
 const data = window.SLACK_EXPORT_DATA;
+
+function normalizeMessageId(value) {
+  return String(value || '').replace(/^message:/, '').trim();
+}
+
+function locationMessageId() {
+  const params = new URLSearchParams(window.location.search);
+  const queryValue = params.get('message') || params.get('messageId');
+  if (queryValue) return normalizeMessageId(queryValue);
+
+  const hash = decodeURIComponent(window.location.hash.replace(/^#/, ''));
+  if (hash.startsWith('message=')) return normalizeMessageId(hash.slice('message='.length));
+  if (hash.startsWith('message:') || hash.startsWith('primary:')) return normalizeMessageId(hash);
+  return '';
+}
+
+function channelIdForMessage(messageId) {
+  const normalized = normalizeMessageId(messageId);
+  if (!normalized) return '';
+  for (const channel of data.channels || []) {
+    if ((channel.messages || []).some(message => normalizeMessageId(message.id) === normalized)) return channel.id;
+  }
+  return '';
+}
+
+const initialMessageId = locationMessageId();
 const state = {
-  channelId: data.channels[0]?.id || '',
+  channelId: channelIdForMessage(initialMessageId) || data.channels[0]?.id || '',
   channelSearch: '',
   messageSearch: '',
   dateFrom: '',
   dateTo: '',
-  systemMode: 'all'
+  systemMode: 'all',
+  targetMessageId: initialMessageId
 };
+let hasScrolledToTarget = false;
 
 const els = {
   exportMeta: document.getElementById('exportMeta'),
@@ -558,6 +590,10 @@ function renderMessages() {
     ? messages.length.toLocaleString() + ' / ' + channel.messageCount.toLocaleString() + ' messages, ' + (channel.firstDate || '-') + ' - ' + (channel.lastDate || '-')
     : '';
   els.messages.innerHTML = sections.length ? sections.map(renderSection).join('') : '<div class="empty">該当するメッセージはありません。</div>';
+  if (state.targetMessageId && !hasScrolledToTarget) {
+    hasScrolledToTarget = true;
+    window.requestAnimationFrame(scrollToTargetMessage);
+  }
 }
 
 function renderSection(section) {
@@ -582,8 +618,9 @@ function renderMessage(message, options) {
   const classNames = ['message'];
   if (message.subtype) classNames.push('system');
   if (opts.isContext) classNames.push('thread-context');
+  if (normalizeMessageId(message.id) === state.targetMessageId) classNames.push('target');
   return (
-    '<article class="' + classNames.join(' ') + '">' +
+    '<article id="' + escapeHtml(messageElementId(message.id)) + '" class="' + classNames.join(' ') + '">' +
       '<div class="message-head">' +
         '<span class="author">' + escapeHtml(message.userName) + '</span>' +
         '<span class="time">' + escapeHtml(formatDateTime(message.timestamp)) + '</span>' +
@@ -594,6 +631,15 @@ function renderMessage(message, options) {
       '<div class="text">' + escapeHtml(message.text || message.rawText || '(no text)') + '</div>' +
     '</article>'
   );
+}
+
+function messageElementId(messageId) {
+  return 'message-' + normalizeMessageId(messageId);
+}
+
+function scrollToTargetMessage() {
+  const element = document.getElementById(messageElementId(state.targetMessageId));
+  if (element) element.scrollIntoView({ block: 'center' });
 }
 
 function render() {

--- a/workers/slack-people-finder/README.md
+++ b/workers/slack-people-finder/README.md
@@ -53,6 +53,7 @@ Cloudflare Workersには以下をsecretとして設定する。
 - `PEOPLE_FINDER_DIRECT_ONLY`: `true` の場合、AI判定が `direct` の候補だけ表示
 - `GEMINI_EMBEDDING_MODEL`: クエリembedding生成モデル
 - `GEMINI_RERANK_MODEL`: 再ランキングモデル
+- `MESSAGE_VIEWER_URL`: 検索結果の根拠メッセージリンク先。GitHub PagesのSlack Exportページを指定する
 
 ## デプロイ
 
@@ -116,7 +117,8 @@ npx wrangler deploy
 ```json
 {
   "MESSAGE_SEARCH_INDEX_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/message-search-index.embedded.json",
-  "PROFILE_SEARCH_INDEX_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/profile-search-index.embedded.json"
+  "PROFILE_SEARCH_INDEX_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/profile-search-index.embedded.json",
+  "MESSAGE_VIEWER_URL": "https://saitekiinc-com.github.io/saiteki-employee-management/slack-export/"
 }
 ```
 

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -14,6 +14,7 @@ const DEFAULT_RERANK_CANDIDATES = 12;
 const DEFAULT_EMBEDDING_MODEL = 'gemini-embedding-001';
 const DEFAULT_EMBEDDING_DIMENSIONS = 768;
 const DEFAULT_RERANK_MODEL = 'gemini-2.0-flash';
+const DEFAULT_MESSAGE_VIEWER_URL = 'https://saitekiinc-com.github.io/saiteki-employee-management/slack-export/';
 
 const INTENT_RANK = {
   direct: 4,
@@ -227,7 +228,8 @@ async function postSearchResults(env, { channel, user, query, category }) {
           results: pages[index],
           totalResults: results.length,
           page: index + 1,
-          totalPages: pages.length
+          totalPages: pages.length,
+          messageViewerUrl: env.MESSAGE_VIEWER_URL || DEFAULT_MESSAGE_VIEWER_URL
         })
       });
     }
@@ -380,7 +382,7 @@ function buildSearchModal({ channelId, initialQuery = '', initialCategory = '仕
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: '*探したい方向を選んで、自然文で入力してください。*\n社員データとメッセージ引用から、近い発言やプロフィール根拠を検索します。'
+          text: '*探したい方向を選んで、自然文で入力してください。*\n社員データと根拠メッセージから、近い発言やプロフィール根拠を検索します。'
         }
       },
       {
@@ -432,7 +434,7 @@ function buttonBlocks({ initialQuery = '', initialCategory = '仕事・相談' }
   ];
 }
 
-function resultMessageBlocks({ query, category, categoryInferred = false, results, totalResults, page, totalPages }) {
+function resultMessageBlocks({ query, category, categoryInferred = false, results, totalResults, page, totalPages, messageViewerUrl }) {
   const categoryText = categoryInferred
     ? `${escapeMrkdwn(category)} (入力内容から自動判定)`
     : escapeMrkdwn(category);
@@ -461,13 +463,13 @@ function resultMessageBlocks({ query, category, categoryInferred = false, result
   ];
 
   for (const result of results) {
-    blocks.push(formatResult(result));
+    blocks.push(formatResult(result, { messageViewerUrl }));
   }
 
   return blocks;
 }
 
-function formatResult(result) {
+function formatResult(result, options = {}) {
   const mention = result.slackIds?.[0] ? `<@${result.slackIds[0]}>` : escapeMrkdwn(result.employeeName);
   const reasons = result.reasons
     .map((reason) => `・${escapeMrkdwn(reason.label)} (${Math.round(reason.score * 100)}%) - ${escapeMrkdwn(reasonSourceLabel(reason))}`)
@@ -476,11 +478,9 @@ function formatResult(result) {
   const rerankNote = result.rerankReason
     ? `${escapeMrkdwn(result.rerankReason)} (${Math.round(Number(result.rerankConfidence || 0) * 100)}%)`
     : '';
-  const quotes = result.messageQuotes
-    .map((quote) => {
-      const quoteText = `「${escapeMrkdwn(truncate(quote.text, 140))}」`;
-      return quote.permalink ? `<${quote.permalink}|${quoteText}>` : quoteText;
-    })
+  const messageLinks = result.messageQuotes
+    .map((quote) => formatMessageReference(quote, options.messageViewerUrl))
+    .filter(Boolean)
     .join('\n');
 
   return {
@@ -492,10 +492,65 @@ function formatResult(result) {
         `選出理由:\n${reasons || '関連する検索facetが閾値を超えました。'}`,
         rerankNote ? `AI判定:\n${rerankNote}` : '',
         detailNotes ? `具体メモ:\n${detailNotes}` : '',
-        quotes ? `メッセージ引用:\n${quotes}` : ''
+        messageLinks ? `根拠メッセージ:\n${messageLinks}` : ''
       ].filter(Boolean).join('\n')
     }
   };
+}
+
+function formatMessageReference(quote, viewerBaseUrl) {
+  const url = messageReferenceUrl(quote, viewerBaseUrl);
+  if (!url) return '';
+  return `・<${url}|${escapeMrkdwn(messageReferenceLabel(quote))}>`;
+}
+
+function messageReferenceUrl(quote, viewerBaseUrl) {
+  const messageId = normalizeMessagePageId(quote.messageId) || messagePageIdFromQuote(quote);
+  const baseUrl = String(viewerBaseUrl || '').trim();
+  if (baseUrl && messageId) {
+    try {
+      const url = new URL(baseUrl);
+      url.searchParams.set('message', messageId);
+      return url.toString();
+    } catch (error) {
+      console.error('Invalid message viewer URL', error);
+    }
+  }
+  return quote.permalink || '';
+}
+
+function messagePageIdFromQuote(quote) {
+  if (!quote.channelId || !quote.messageTs) return '';
+  return `${quote.workspace || 'primary'}:${quote.channelId}:${quote.messageTs}`;
+}
+
+function normalizeMessagePageId(messageId) {
+  return String(messageId || '').replace(/^message:/, '').trim();
+}
+
+function messageReferenceLabel(quote) {
+  return [
+    quote.channelName ? `#${quote.channelName}` : quote.channelId ? `#${quote.channelId}` : 'Slackメッセージ',
+    quote.authorName,
+    formatMessageDate(quote.messageTs)
+  ].filter(Boolean).join(' / ');
+}
+
+function formatMessageDate(messageTs) {
+  const millis = Number.parseFloat(messageTs || '0') * 1000;
+  if (!Number.isFinite(millis) || millis <= 0) return '';
+  try {
+    return new Intl.DateTimeFormat('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
+    }).format(new Date(millis));
+  } catch {
+    return '';
+  }
 }
 
 function reasonDetailNotes(reason) {

--- a/workers/slack-people-finder/wrangler.jsonc
+++ b/workers/slack-people-finder/wrangler.jsonc
@@ -21,6 +21,7 @@
     "GEMINI_EMBEDDING_MODEL": "gemini-embedding-001",
     "GEMINI_EMBEDDING_DIMENSIONS": "768",
     "GEMINI_RERANK_MODEL": "gemini-2.0-flash",
+    "MESSAGE_VIEWER_URL": "https://saitekiinc-com.github.io/saiteki-employee-management/slack-export/",
     "MESSAGE_SEARCH_INDEX_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/message-search-index.embedded.json",
     "PROFILE_SEARCH_INDEX_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/profile-search-index.embedded.json",
     "SEARCH_FACETS_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/search-facets.jsonld"


### PR DESCRIPTION
## 概要
- Slack検索結果の「メッセージ引用」を、GitHub PagesのSlack Exportページへの「根拠メッセージ」リンクに置き換え
- MESSAGE_VIEWER_URL をWorker varsに追加し、message id付きURLを生成
- Slack Exportページで message パラメータを受け取り、該当チャンネルを開いて対象投稿をハイライト・スクロール
- Slack Export生成スクリプトにも同じディープリンク対応を反映

## ブランチ・PR戦略
- base: main
- working branch: codex/link-message-results-to-pages-20260528
- PR size budget: 300行以内（今回 5ファイル / +169 -19）
- split criteria: Slack Exportのデータ再生成や検索ロジック変更は別PR
- PR creation timing: 実装・ローカル生成確認・テスト・wrangler dry-run 後

## 確認
- node --check scripts/build-slack-export-pages.js
- npm run build:slack-export-pages -- --export-dir ".../Saiteki Slack export Oct 21 2025 - May 27 2026" --output-dir temp --messages-file temp
- npm run test:message-vector
- npm run test:profile-vector-search
- git diff --check
- cd workers/slack-people-finder && npx wrangler deploy --dry-run

## リスク
- GitHub PagesのSlack Exportデータに存在しない古い/未同期メッセージIDの場合、ページは開くがハイライト対象が見つかりません。
- Slack本文には引用本文を出さなくなるため、根拠確認はリンク先ページで行う前提になります。
