### PR TITLE
Slackメッセージ検索の根拠なし候補を除外

### DIFF
--- a/scripts/people-finder-vector-search.js
+++ b/scripts/people-finder-vector-search.js
@@ -15,6 +15,50 @@ const DEFAULT_INDEX_FILE = path.join(__dirname, '../data/profile-search-index.em
 const DEFAULT_THRESHOLD = 0.22;
 const DEFAULT_TOP_UNITS = 80;
 
+const QUERY_EVIDENCE_ALIASES = {
+  qa: ['品質保証'],
+  品質保証: ['qa'],
+  ポケモン: [
+    'pokemon',
+    'pokémon',
+    'ポケカ',
+    'ピカチュウ',
+    'アチャモ',
+    'バシャーモ',
+    'ポッチャマ',
+    'ヒノアラシ',
+    'ダイパ',
+    'ルビサファ',
+    'テンガン山',
+    'テッカニン',
+    'ドダイトス'
+  ],
+  ポケカ: ['ポケモン', 'pokemon', 'pokémon'],
+  pokemon: ['ポケモン', 'ポケカ', 'pokémon'],
+  pokémon: ['ポケモン', 'ポケカ', 'pokemon'],
+  セキュリティ: ['security', '情報セキュリティ', '脆弱性', 'csirt', 'siem', 'ゼロトラスト']
+};
+
+const QUERY_EVIDENCE_STOP_TERMS = new Set([
+  'こと',
+  'もの',
+  'できる',
+  '詳しい',
+  '仕事',
+  '相談',
+  '社員',
+  '興味',
+  '人柄',
+  '好き',
+  '趣味',
+  '休日',
+  '最近',
+  '話せる',
+  '探し',
+  '教えて',
+  'エンジニア'
+]);
+
 function parseArgs(argv) {
   const args = {};
   for (let index = 0; index < argv.length; index++) {
@@ -124,14 +168,60 @@ function lexicalLabelBoost(unit, queryText) {
   return Math.min(matched * weight, cap);
 }
 
+function queryEvidenceTerms(queryText) {
+  const normalized = normalizeText(queryText);
+  if (!normalized) return [];
+
+  const terms = [];
+  for (const term of normalized.split(/\s+/)) {
+    if (isUsefulEvidenceTerm(term)) terms.push(term);
+  }
+
+  for (const term of normalized.match(/[a-z0-9+#.]{2,}/g) || []) {
+    if (isUsefulEvidenceTerm(term)) terms.push(term);
+  }
+
+  for (const [term, aliases] of Object.entries(QUERY_EVIDENCE_ALIASES)) {
+    if (!normalized.includes(normalizeText(term))) continue;
+    terms.push(normalizeText(term));
+    terms.push(...aliases.map(normalizeText));
+  }
+
+  return [...new Set(terms.filter(Boolean))];
+}
+
+function isUsefulEvidenceTerm(term) {
+  const normalized = normalizeText(term);
+  return normalized.length >= 2 && !QUERY_EVIDENCE_STOP_TERMS.has(normalized);
+}
+
+function unitHasQueryEvidence(unit, evidenceTerms) {
+  if (unit.semanticType !== 'slack_message' || evidenceTerms.length === 0) return true;
+  const text = unitEvidenceText(unit);
+  return evidenceTerms.some((term) => text.includes(term));
+}
+
+function unitEvidenceText(unit) {
+  return normalizeText([
+    unit.searchText,
+    unit.relationLabel,
+    unit.topicLabel,
+    ...(unit.topicAliases || []),
+    ...(unit.detailBullets || []),
+    ...(unit.quotes || []).map((quote) => quote.text)
+  ].filter(Boolean).join(' '));
+}
+
 async function searchProfileVectors(index, query, provider, options = {}) {
   ensureEmbedded(index);
   const threshold = Number(options.threshold ?? DEFAULT_THRESHOLD);
   const topUnits = Number(options.topUnits || DEFAULT_TOP_UNITS);
   const queryText = stripQueryHelpers(query) || normalizeText(query);
+  const evidenceTerms = queryEvidenceTerms(queryText);
   const queryVector = await provider.embed(queryText, 'query');
 
   const scoredUnits = (index['@graph'] || [])
+    .filter((unit) => unitHasQueryEvidence(unit, evidenceTerms))
     .map((unit) => ({
       unit,
       score: cosineSimilarity(queryVector, unitVector(unit)) + lexicalLabelBoost(unit, queryText)

--- a/scripts/test-message-vector-search.js
+++ b/scripts/test-message-vector-search.js
@@ -76,6 +76,17 @@ async function main() {
         detailBullets: ['休日はポケモンのゲームとポケカをしています'],
         quotes: [{ text: '休日はポケモンのゲームとポケカをしています' }],
         embedding: { vector: [0, 1] }
+      },
+      {
+        '@id': 'search-message:vector-only-unrelated',
+        personName: '無関係 次郎',
+        semanticType: 'slack_message',
+        relationLabel: 'Slack発言: 雑談',
+        topicLabel: '雑談',
+        searchText: '皆様ありがとうございます！',
+        detailBullets: ['皆様ありがとうございます！'],
+        quotes: [{ text: '皆様ありがとうございます！' }],
+        embedding: { vector: [1, 0] }
       }
     ]
   };
@@ -89,6 +100,10 @@ async function main() {
     topUnits: 10
   });
   assert.strictEqual(lexicalOnly[0]?.employeeName, '本文一致 太郎', 'message text matches should survive even when vector similarity is weak');
+  assert(
+    !lexicalOnly.some((result) => result.employeeName === '無関係 次郎'),
+    'message vector search should drop vector-near results when the message body has no query evidence'
+  );
 
   console.log('message vector search OK');
 }

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -16,6 +16,50 @@ const DEFAULT_EMBEDDING_DIMENSIONS = 768;
 const DEFAULT_RERANK_MODEL = 'gemini-2.0-flash';
 const DEFAULT_MESSAGE_VIEWER_URL = 'https://saitekiinc-com.github.io/saiteki-employee-management/slack-export/';
 
+const QUERY_EVIDENCE_ALIASES = {
+  qa: ['品質保証'],
+  品質保証: ['qa'],
+  ポケモン: [
+    'pokemon',
+    'pokémon',
+    'ポケカ',
+    'ピカチュウ',
+    'アチャモ',
+    'バシャーモ',
+    'ポッチャマ',
+    'ヒノアラシ',
+    'ダイパ',
+    'ルビサファ',
+    'テンガン山',
+    'テッカニン',
+    'ドダイトス'
+  ],
+  ポケカ: ['ポケモン', 'pokemon', 'pokémon'],
+  pokemon: ['ポケモン', 'ポケカ', 'pokémon'],
+  pokémon: ['ポケモン', 'ポケカ', 'pokemon'],
+  セキュリティ: ['security', '情報セキュリティ', '脆弱性', 'csirt', 'siem', 'ゼロトラスト']
+};
+
+const QUERY_EVIDENCE_STOP_TERMS = new Set([
+  'こと',
+  'もの',
+  'できる',
+  '詳しい',
+  '仕事',
+  '相談',
+  '社員',
+  '興味',
+  '人柄',
+  '好き',
+  '趣味',
+  '休日',
+  '最近',
+  '話せる',
+  '探し',
+  '教えて',
+  'エンジニア'
+]);
+
 const INTENT_RANK = {
   direct: 4,
   adjacent: 3,
@@ -615,6 +659,7 @@ async function searchVectorIndex(env, index, query, options = {}) {
   ensureEmbeddedIndex(index);
 
   const queryText = stripQueryHelpers(query) || normalizeText(query);
+  const evidenceTerms = queryEvidenceTerms(queryText);
   const queryVector = await embedQuery(env, queryText, index.embedding?.model, firstVectorDimensions(index));
   const threshold = parseNumber(options.threshold, DEFAULT_VECTOR_THRESHOLD);
   const topUnits = parseNumber(env.PEOPLE_FINDER_VECTOR_TOP_UNITS, DEFAULT_TOP_UNITS);
@@ -623,6 +668,7 @@ async function searchVectorIndex(env, index, query, options = {}) {
 
   const scoredUnits = graph
     .filter((unit) => !uiCategory || !unit.uiCategory || unit.uiCategory === uiCategory)
+    .filter((unit) => unitHasQueryEvidence(unit, evidenceTerms))
     .map((unit) => ({
       unit,
       score: cosineVectorSimilarity(queryVector, unitVector(unit)) + lexicalLabelBoost(unit, queryText)
@@ -691,6 +737,50 @@ function lexicalLabelBoost(unit, queryText) {
   const weight = unit.semanticType === 'slack_message' ? 0.09 : 0.06;
   const cap = unit.semanticType === 'slack_message' ? 0.24 : 0.18;
   return Math.min(matched * weight, cap);
+}
+
+function queryEvidenceTerms(queryText) {
+  const normalized = normalizeText(queryText);
+  if (!normalized) return [];
+
+  const terms = [];
+  for (const term of normalized.split(/\s+/)) {
+    if (isUsefulEvidenceTerm(term)) terms.push(term);
+  }
+
+  for (const term of normalized.match(/[a-z0-9+#.]{2,}/g) || []) {
+    if (isUsefulEvidenceTerm(term)) terms.push(term);
+  }
+
+  for (const [term, aliases] of Object.entries(QUERY_EVIDENCE_ALIASES)) {
+    if (!normalized.includes(normalizeText(term))) continue;
+    terms.push(normalizeText(term));
+    terms.push(...aliases.map(normalizeText));
+  }
+
+  return [...new Set(terms.filter(Boolean))];
+}
+
+function isUsefulEvidenceTerm(term) {
+  const normalized = normalizeText(term);
+  return normalized.length >= 2 && !QUERY_EVIDENCE_STOP_TERMS.has(normalized);
+}
+
+function unitHasQueryEvidence(unit, evidenceTerms) {
+  if (unit.semanticType !== 'slack_message' || evidenceTerms.length === 0) return true;
+  const text = unitEvidenceText(unit);
+  return evidenceTerms.some((term) => text.includes(term));
+}
+
+function unitEvidenceText(unit) {
+  return normalizeText([
+    unit.searchText,
+    unit.relationLabel,
+    unit.topicLabel,
+    ...(unit.topicAliases || []),
+    ...(unit.detailBullets || []),
+    ...(unit.quotes || []).map((quote) => quote.text)
+  ].filter(Boolean).join(' '));
 }
 
 function aggregateVectorUnits(scoredUnits, threshold) {


### PR DESCRIPTION
## 概要
- Slackメッセージ由来のベクトル検索候補に、クエリを支える本文・引用・メモがあるかのガードを追加
- 「ポケモン」では `ゲーム` や短いn-gramでは通さず、ポケカ・ピカチュウ・アチャモ・ダイパなど固有の根拠語だけを許可
- ローカル検索スクリプトにも同じガードを入れ、ベクトルだけ近い無関係メッセージを落とす回帰テストを追加

## ブランチ・PR戦略
- base: `main`
- working branch: `codex/filter-unsupported-message-results-20260528`
- PRサイズ: 3ファイル / 195行追加。検索ロジックと検証だけに限定
- 分割基準: 表示文言変更、追加の同義語チューニング、再ランキング改善は別PR
- 作成タイミング: 実装・ローカル検証・dry-run後に作成

## テスト
- `npm run test:message-vector`
- `npm run test:profile-vector-search`
- `npm run test:people-finder-rerank`
- `npm run test:people-finder`
- `npm run test:profile-search-index`
- `git diff --check`
- `npx wrangler deploy --dry-run --config workers/slack-people-finder/wrangler.jsonc`

## 残リスク
- Gemini本番埋め込みの実際の順位はAPIキーなしのローカルでは完全再現していません。ただし、候補化前の根拠ガードなので、本文根拠がない2ページ目のような候補は落ちる設計です。
- ポケモン固有語の辞書は必要最小限です。追加したい作品名・キャラ名が出た場合は小さく増やせます。