### PR TITLE
AWS検索が0件になる経路を修正

### DIFF
--- a/scripts/rerank-people-finder-results.js
+++ b/scripts/rerank-people-finder-results.js
@@ -53,6 +53,7 @@ function buildRerankPrompt(query, results) {
 ルール:
 - 根拠にない推測はしない
 - 「QAエンジニア」のような職種検索では、AI、エンジニア、影響力だけの候補は reject または weak
+- AWS、Azure、Reactのような短い技術名・製品名は、実務経験や具体的な話題として根拠に出ていれば direct
 - 「ポケモン」のような趣味検索では、具体的な接点がある候補を direct
 - Slackメッセージ検索では、候補内の実発言・引用・具体メモだけを根拠にする
 - クエリ語の言い換え、同義語、関連する固有名詞は考慮してよい
@@ -217,19 +218,23 @@ function applyDecisions(results, decisions, options = {}) {
         ? result.reasons.filter((reason) => selectedIds.has(reason.unitId))
         : result.reasons;
       const slackMessageResult = isSlackMessageResult(result);
-      if (slackMessageResult && (decision.evidenceSupported === false || selectedIds.size === 0 || selectedReasons.length === 0)) {
+      if (slackMessageResult && decision.evidenceSupported === false) {
         return null;
       }
+      const displayReasons = selectedReasons.length > 0 ? selectedReasons : result.reasons;
       const selectedQuotes = selectedIds.size > 0
         ? filterQuotesByReasonIds(result.quotes || [], selectedIds)
         : result.quotes;
+      const displayQuotes = selectedQuotes.length > 0
+        ? selectedQuotes
+        : filterQuotesByReasonIds(result.quotes || [], new Set(displayReasons.map((reason) => reason.unitId)));
       return {
         ...result,
         intentFit: decision.intentFit,
         rerankConfidence: decision.confidence,
         rerankReason: decision.reason,
-        reasons: selectedReasons.length > 0 ? selectedReasons : result.reasons,
-        quotes: slackMessageResult ? selectedQuotes : (selectedQuotes || result.quotes)
+        reasons: displayReasons,
+        quotes: slackMessageResult ? displayQuotes : (displayQuotes || result.quotes)
       };
     })
     .filter(Boolean)

--- a/scripts/test-people-finder-rerank.js
+++ b/scripts/test-people-finder-rerank.js
@@ -6,7 +6,7 @@ const { buildProfileSearchIndex } = require('./build-profile-search-index');
 const { embedProfileSearchIndex } = require('./embed-profile-search-index');
 const { searchProfileVectors } = require('./people-finder-vector-search');
 const { createLocalFixtureProvider } = require('./profile-embedding-utils');
-const { createReranker, rerankPeopleResults } = require('./rerank-people-finder-results');
+const { applyDecisions, createReranker, rerankPeopleResults } = require('./rerank-people-finder-results');
 
 async function main() {
   const profileGraph = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/employee-profile-graph.jsonld'), 'utf8'));
@@ -51,6 +51,52 @@ async function main() {
     pokemonReranked.every((result) => ['direct', 'adjacent'].includes(result.intentFit)),
     'rerank should only return displayable intent fits'
   );
+
+  const awsMessageResults = [
+    {
+      employeeName: 'AWS 太郎',
+      score: 0.8,
+      reasons: [
+        {
+          unitId: 'search-message:primary:C1:123.456',
+          semanticType: 'slack_message',
+          relationLabel: 'Slack発言: 自己紹介',
+          topicLabel: '自己紹介',
+          detailBullets: ['AWS運用構築の経験があります']
+        }
+      ],
+      quotes: [
+        {
+          unitId: 'search-message:primary:C1:123.456',
+          messageId: 'message:primary:C1:123.456',
+          text: 'AWS運用構築の経験があります'
+        }
+      ]
+    }
+  ];
+  const idMismatchKept = applyDecisions(awsMessageResults, [
+    {
+      employeeName: 'AWS 太郎',
+      intentFit: 'direct',
+      confidence: 0.9,
+      reason: 'AWS経験の根拠がある',
+      evidenceSupported: true,
+      selectedReasonUnitIds: ['提示されたunitId']
+    }
+  ]);
+  assert.strictEqual(idMismatchKept.length, 1, 'LLM-supported Slack message result should survive when only the returned reason id format is invalid');
+
+  const unsupportedDropped = applyDecisions(awsMessageResults, [
+    {
+      employeeName: 'AWS 太郎',
+      intentFit: 'reject',
+      confidence: 0.1,
+      reason: '根拠がない',
+      evidenceSupported: false,
+      selectedReasonUnitIds: []
+    }
+  ]);
+  assert.strictEqual(unsupportedDropped.length, 0, 'unsupported Slack message result should still be dropped');
 
   console.log('people finder rerank OK');
 }

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -242,7 +242,9 @@ async function postSearchResults(env, { channel, user, query, category }) {
 async function searchPeople(env, query, categoryResolution) {
   if (canUseMessageSearch(env)) {
     try {
-      return await searchMessageIndex(env, query);
+      const messageResults = await searchMessageIndex(env, query);
+      if (messageResults.length > 0) return messageResults;
+      console.warn('Message vector people search returned no results; falling back to profile vector search');
     } catch (error) {
       console.error('Message vector people search failed; falling back to profile search', error);
     }
@@ -844,6 +846,7 @@ function buildRerankPrompt(query, results) {
 ルール:
 - 根拠にない推測はしない
 - 職種検索では、AI、エンジニア、影響力だけの候補は reject または weak
+- AWS、Azure、Reactのような短い技術名・製品名は、実務経験や具体的な話題として根拠に出ていれば direct
 - 趣味検索では、具体的な接点がある候補を direct
 - Slackメッセージ検索では、候補内の実発言・引用・具体メモだけを根拠にする
 - クエリ語の言い換え、同義語、関連する固有名詞は考慮してよい
@@ -907,19 +910,23 @@ function applyRerankDecisions(results, decisions, options = {}) {
         ? result.reasons.filter((reason) => selectedIds.has(reason.unitId))
         : result.reasons;
       const slackMessageResult = isSlackMessageResult(result);
-      if (slackMessageResult && (decision.evidenceSupported === false || selectedIds.size === 0 || selectedReasons.length === 0)) {
+      if (slackMessageResult && decision.evidenceSupported === false) {
         return null;
       }
+      const displayReasons = selectedReasons.length > 0 ? selectedReasons : result.reasons;
       const selectedMessageQuotes = selectedIds.size > 0
         ? filterMessageQuotesByReasonIds(result.messageQuotes || [], selectedIds)
         : result.messageQuotes;
+      const displayMessageQuotes = selectedMessageQuotes.length > 0
+        ? selectedMessageQuotes
+        : filterMessageQuotesByReasonIds(result.messageQuotes || [], new Set(displayReasons.map((reason) => reason.unitId)));
       return {
         ...result,
         intentFit: decision.intentFit,
         rerankConfidence: decision.confidence,
         rerankReason: decision.reason,
-        reasons: selectedReasons.length > 0 ? selectedReasons : result.reasons,
-        messageQuotes: slackMessageResult ? selectedMessageQuotes : (selectedMessageQuotes || result.messageQuotes)
+        reasons: displayReasons,
+        messageQuotes: slackMessageResult ? displayMessageQuotes : (displayMessageQuotes || result.messageQuotes)
       };
     })
     .filter(Boolean)


### PR DESCRIPTION
## 概要
- メッセージ検索が0件だった場合、facetではなくプロフィールベクトル検索へ進むようにしました
- LLMが根拠ありと判定した候補は、selectedReasonUnitIds の形式が多少ズレても候補全体を落とさないようにしました
- AWS/Azure/Reactのような短い技術名・製品名は、実務経験や具体的話題に出ていれば direct と判定するようプロンプトを補強しました
- 回帰テストとして、LLMの理由ID形式だけがズレたSlackメッセージ候補を保持し、evidenceSupported=false は落とすケースを追加しました

## 原因
- 本番は `MESSAGE_SEARCH_INDEX_URL` がある場合、メッセージ検索を先に使います
- その結果が空配列でもそこで終了しており、プロフィールベクトル検索まで進んでいませんでした
- さらに、LLMが根拠ありと判定しても `selectedReasonUnitIds` の返却形式が完全一致しないと候補ごと落とす実装になっていました

## ブランチ・PR戦略
- base: `main`
- working branch: `codex/fix-empty-message-search-fallback-20260528`
- PRサイズ: 3ファイル、66行追加 / 8行削除。検索制御とLLM判定適用のみ
- 分割基準: AWS専用辞書、閾値調整、表示文言変更は別PR
- 作成タイミング: テスト・dry-run後に作成

## テスト
- `npm run test:people-finder-rerank`
- `npm run test:message-vector`
- `npm run test:profile-vector-search`
- `npm run test:people-finder`
- `npm run test:profile-search-index`
- `git diff --check`
- `npx wrangler deploy --dry-run --config workers/slack-people-finder/wrangler.jsonc`

## 補足
- ローカルのメッセージindexでは `AWS` で深尾航輝、真栄城則明、宍戸佑衣、青木淳一郎などのAWS根拠が確認できています。