### PR TITLE
People FinderのGeminiモデルを3.5 Flashへ更新

### DIFF
--- a/scripts/rerank-people-finder-results.js
+++ b/scripts/rerank-people-finder-results.js
@@ -90,7 +90,7 @@ async function createGeminiReranker(options = {}) {
     throw new Error('GEMINI_API_KEY is required for gemini reranker. Use --reranker local-fixture for tests.');
   }
   const { GoogleGenerativeAI } = require('@google/generative-ai');
-  const modelName = options.model || process.env.GEMINI_RERANK_MODEL || 'gemini-2.0-flash';
+  const modelName = options.model || process.env.GEMINI_RERANK_MODEL || 'gemini-3.5-flash';
   const genAI = new GoogleGenerativeAI(apiKey);
   const model = genAI.getGenerativeModel({
     model: modelName,

--- a/workers/slack-people-finder/README.md
+++ b/workers/slack-people-finder/README.md
@@ -52,7 +52,7 @@ Cloudflare Workersには以下をsecretとして設定する。
 - `PEOPLE_FINDER_RERANK_CANDIDATES`: AI再ランキング対象の候補社員数
 - `PEOPLE_FINDER_DIRECT_ONLY`: `true` の場合、AI判定が `direct` の候補だけ表示
 - `GEMINI_EMBEDDING_MODEL`: クエリembedding生成モデル
-- `GEMINI_RERANK_MODEL`: 再ランキングモデル
+- `GEMINI_RERANK_MODEL`: 再ランキング・質問解釈・回答生成モデル。既定は `gemini-3.5-flash`
 - `MESSAGE_VIEWER_URL`: 検索結果の根拠メッセージリンク先。GitHub PagesのSlack Exportページを指定する
 
 ## デプロイ

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -13,7 +13,7 @@ const DEFAULT_TOP_UNITS = 80;
 const DEFAULT_RERANK_CANDIDATES = 12;
 const DEFAULT_EMBEDDING_MODEL = 'gemini-embedding-001';
 const DEFAULT_EMBEDDING_DIMENSIONS = 768;
-const DEFAULT_RERANK_MODEL = 'gemini-2.0-flash';
+const DEFAULT_RERANK_MODEL = 'gemini-3.5-flash';
 const DEFAULT_MESSAGE_VIEWER_URL = 'https://saitekiinc-com.github.io/saiteki-employee-management/slack-export/';
 
 const INTENT_RANK = {
@@ -293,7 +293,19 @@ async function searchPeopleAnswer(env, query, categoryResolution) {
         })
       };
     } catch (error) {
-      console.error('People answer generation failed; returning ranked candidates', error);
+      console.error('People answer generation failed', error);
+      return {
+        blocks: answerMessageBlocks({
+          query,
+          category: categoryResolution.category,
+          categoryInferred: categoryResolution.inferred,
+          plan,
+          answer: 'AI回答生成に失敗しました。検索候補は取得できていますが、質問意図に沿った根拠判定が完了しなかったため、候補一覧の表示を止めました。少し時間を置いて再実行してください。',
+          selected: [],
+          candidates: [],
+          messageViewerUrl
+        })
+      };
     }
   }
 

--- a/workers/slack-people-finder/wrangler.jsonc
+++ b/workers/slack-people-finder/wrangler.jsonc
@@ -20,7 +20,7 @@
     "PEOPLE_FINDER_DIRECT_ONLY": "false",
     "GEMINI_EMBEDDING_MODEL": "gemini-embedding-001",
     "GEMINI_EMBEDDING_DIMENSIONS": "768",
-    "GEMINI_RERANK_MODEL": "gemini-2.0-flash",
+    "GEMINI_RERANK_MODEL": "gemini-3.5-flash",
     "MESSAGE_VIEWER_URL": "https://saitekiinc-com.github.io/saiteki-employee-management/slack-export/",
     "MESSAGE_SEARCH_INDEX_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/message-search-index.embedded.json",
     "PROFILE_SEARCH_INDEX_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/profile-search-index.embedded.json",
@@ -29,7 +29,8 @@
   "secrets": {
     "required": [
       "SLACK_SIGNING_SECRET",
-      "SLACK_BOT_TOKEN_3"
+      "SLACK_BOT_TOKEN_3",
+      "GEMINI_API_KEY"
     ]
   }
 }


### PR DESCRIPTION
## 概要
- Slack People Finderの再ランキング・質問解釈・回答生成モデルを `gemini-2.0-flash` から `gemini-3.5-flash` に更新しました。
- `gemini-2.0-flash` は現在のGemini API docs上でPrevious/Deprecated側に入っているため、回答生成失敗の要因になりうる設定を解消します。
- LLM回答生成が失敗した場合に、低品質な旧候補リストへ静かにフォールバックせず、回答生成失敗として表示するようにしました。
- ローカル再ランキングスクリプトとREADMEの既定モデル表記も合わせました。
- Worker secretのrequired一覧に `GEMINI_API_KEY` を追加しました。

## ブランチ・PR戦略
- ベースブランチ: main
- 作業ブランチ: codex/update-gemini-rerank-model-20260528
- PRサイズ目安: 300行前後
- 実差分: 4ファイル、約25行。モデル更新と失敗時挙動の小修正のため1 PRにまとめます。
- 分割基準: 実クエリ結果を見てプロンプト改善や検索ロジック改善が必要なら後続PRで分けます。
- PR作成タイミング: 実装、検索系テスト、Worker dry-run完了後。

## 検証
- node --check workers/slack-people-finder/src/index.js
- npm run test:people-finder
- npm run test:people-finder-rerank
- npm run test:message-vector
- npm run test:profile-vector-search
- npm run test:profile-search-index
- git diff --check
- npx wrangler deploy --dry-run --config workers/slack-people-finder/wrangler.jsonc

## 残リスク
- 本番Slackでの `AWS経験者` 実行結果はデプロイ後に確認が必要です。
- もし `gemini-3.5-flash` の権限・課金・リージョン制約で失敗する場合、明示的な失敗メッセージが出るため、次はWorkerログで原因を追います。