### PR TITLE
People FinderのGeminiモデル指定を安定版に修正

### DIFF
--- a/scripts/rerank-people-finder-results.js
+++ b/scripts/rerank-people-finder-results.js
@@ -90,7 +90,7 @@ async function createGeminiReranker(options = {}) {
     throw new Error('GEMINI_API_KEY is required for gemini reranker. Use --reranker local-fixture for tests.');
   }
   const { GoogleGenerativeAI } = require('@google/generative-ai');
-  const modelName = options.model || process.env.GEMINI_RERANK_MODEL || 'gemini-3.5-flash';
+  const modelName = options.model || process.env.GEMINI_RERANK_MODEL || 'gemini-2.5-flash';
   const genAI = new GoogleGenerativeAI(apiKey);
   const model = genAI.getGenerativeModel({
     model: modelName,

--- a/workers/slack-people-finder/README.md
+++ b/workers/slack-people-finder/README.md
@@ -52,7 +52,7 @@ Cloudflare Workersには以下をsecretとして設定する。
 - `PEOPLE_FINDER_RERANK_CANDIDATES`: AI再ランキング対象の候補社員数
 - `PEOPLE_FINDER_DIRECT_ONLY`: `true` の場合、AI判定が `direct` の候補だけ表示
 - `GEMINI_EMBEDDING_MODEL`: クエリembedding生成モデル
-- `GEMINI_RERANK_MODEL`: 再ランキング・質問解釈・回答生成モデル。既定は `gemini-3.5-flash`
+- `GEMINI_RERANK_MODEL`: 再ランキング・質問解釈・回答生成モデル。既定は `gemini-2.5-flash`
 - `MESSAGE_VIEWER_URL`: 検索結果の根拠メッセージリンク先。GitHub PagesのSlack Exportページを指定する
 
 ## デプロイ

--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -13,7 +13,7 @@ const DEFAULT_TOP_UNITS = 80;
 const DEFAULT_RERANK_CANDIDATES = 12;
 const DEFAULT_EMBEDDING_MODEL = 'gemini-embedding-001';
 const DEFAULT_EMBEDDING_DIMENSIONS = 768;
-const DEFAULT_RERANK_MODEL = 'gemini-3.5-flash';
+const DEFAULT_RERANK_MODEL = 'gemini-2.5-flash';
 const DEFAULT_MESSAGE_VIEWER_URL = 'https://saitekiinc-com.github.io/saiteki-employee-management/slack-export/';
 
 const INTENT_RANK = {

--- a/workers/slack-people-finder/wrangler.jsonc
+++ b/workers/slack-people-finder/wrangler.jsonc
@@ -20,7 +20,7 @@
     "PEOPLE_FINDER_DIRECT_ONLY": "false",
     "GEMINI_EMBEDDING_MODEL": "gemini-embedding-001",
     "GEMINI_EMBEDDING_DIMENSIONS": "768",
-    "GEMINI_RERANK_MODEL": "gemini-3.5-flash",
+    "GEMINI_RERANK_MODEL": "gemini-2.5-flash",
     "MESSAGE_VIEWER_URL": "https://saitekiinc-com.github.io/saiteki-employee-management/slack-export/",
     "MESSAGE_SEARCH_INDEX_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/message-search-index.embedded.json",
     "PROFILE_SEARCH_INDEX_URL": "https://raw.githubusercontent.com/Saitekiinc-com/saiteki-employee-management/main/data/profile-search-index.embedded.json",


### PR DESCRIPTION
## 概要
- `gemini-3.5-flash` はGemini APIの有効なモデルコードではなかったため、安定版の `gemini-2.5-flash` に修正しました。
- Worker設定、Worker内デフォルト、ローカルrerankスクリプト、READMEのモデル表記を統一しました。

## ブランチ・PR戦略
- ベースブランチ: main
- 作業ブランチ: codex/fix-supported-gemini-model-20260528
- PRサイズ目安: 300行前後
- 実差分: 4ファイル、4行変更。誤ったモデル指定の緊急修正として1 PRにまとめます。
- 分割基準: 投稿されない原因がモデル指定以外にも残る場合、ログ確認後に後続PRで修正します。
- PR作成タイミング: テストとWorker dry-run完了後。

## 検証
- node --check workers/slack-people-finder/src/index.js
- npm run test:people-finder
- npm run test:people-finder-rerank
- npm run test:message-vector
- npm run test:profile-vector-search
- npm run test:profile-search-index
- git diff --check
- npx wrangler deploy --dry-run --config workers/slack-people-finder/wrangler.jsonc

## 残リスク
- 本番Slackでの投稿復旧確認はデプロイ後に必要です。
- まだ投稿されない場合は、Worker tailでSlack APIエラーまたはGemini APIエラーを追います。