### PR TITLE
未登録Slackユーザーとメッセージを軽量反映する

### DIFF
--- a/.github/workflows/slack-lightweight-reflect.yml
+++ b/.github/workflows/slack-lightweight-reflect.yml
@@ -1,0 +1,61 @@
+name: Lightweight Slack Reflect
+
+on:
+  workflow_dispatch:
+    inputs:
+      full_sync:
+        description: '全期間の履歴を取得しますか？'
+        type: boolean
+        default: false
+
+jobs:
+  reflect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync Slack Users and Messages
+        run: |
+          if [ "${{ github.event.inputs.full_sync }}" = "true" ]; then
+            node scripts/sync-slack.js --full --profile-analysis=none
+          else
+            node scripts/sync-slack.js --profile-analysis=none
+          fi
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN || secrets.SLACK_APP_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_BOT_TOKEN_2: ${{ secrets.SLACK_BOT_TOKEN_2 }}
+          SLACK_CHANNEL_ID_2: ${{ secrets.SLACK_CHANNEL_ID_2 }}
+
+      - name: Build Message Search Index
+        run: npm run build:message-search-index
+
+      - name: Embed Message Search Index
+        run: npm run embed:message-search-index
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+      - name: Build Slack Export Pages
+        run: npm run build:slack-export-pages
+
+      - name: Commit and Push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add data/employees.json data/slack-messages.jsonl data/message-search-index.json data/message-search-index.embedded.json docs/TEAM.md docs/slack-export
+          if git diff --staged --quiet; then
+            echo "No lightweight Slack reflection changes to commit"
+          else
+            git commit -m "Auto: Reflect Slack users and messages"
+            git push
+          fi

--- a/scripts/sync-slack.js
+++ b/scripts/sync-slack.js
@@ -24,11 +24,21 @@ const ENDPOINT_ID = process.env.GCP_ENDPOINT_ID;
 // Parse command line arguments
 const args = process.argv.slice(2);
 const IS_FULL_SYNC = args.includes('--full');
+const PROFILE_ANALYSIS_MODE = optionValue('profile-analysis') || process.env.SLACK_PROFILE_ANALYSIS || 'all';
+const SHOULD_ANALYZE_PROFILES = PROFILE_ANALYSIS_MODE !== 'none';
 
 
 async function main() {
-    if (!SLACK_TOKEN || CHANNEL_IDS.length === 0 || !API_KEY || !PROJECT_ID) {
-        console.error('Missing required environment variables: SLACK_BOT_TOKEN, SLACK_CHANNEL_ID, GEMINI_API_KEY, GCP_PROJECT_ID');
+    if (!['all', 'none'].includes(PROFILE_ANALYSIS_MODE)) {
+        console.error('Invalid --profile-analysis value. Use "all" or "none".');
+        process.exit(1);
+    }
+
+    if (!SLACK_TOKEN || CHANNEL_IDS.length === 0 || (SHOULD_ANALYZE_PROFILES && (!API_KEY || !PROJECT_ID))) {
+        const required = SHOULD_ANALYZE_PROFILES
+            ? 'SLACK_BOT_TOKEN, SLACK_CHANNEL_ID, GEMINI_API_KEY, GCP_PROJECT_ID'
+            : 'SLACK_BOT_TOKEN, SLACK_CHANNEL_ID';
+        console.error(`Missing required environment variables: ${required}`);
         process.exit(1);
     }
 
@@ -44,6 +54,7 @@ async function main() {
     const employees = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
 
     console.log(`Starting sync... Full Mode: ${IS_FULL_SYNC}`);
+    console.log(`Profile analysis mode: ${PROFILE_ANALYSIS_MODE}`);
     console.log(`Target Channels: ${CHANNEL_IDS.join(', ')}`);
 
     // Fetch messages from ALL channels (Primary Workspace)
@@ -94,6 +105,17 @@ async function main() {
     const registration = await registerSlackUsersFromMessages(employees, mergedSlackMessages);
     if (registration.changedCount > 0) {
         console.log(`Registered ${registration.createdCount} new Slack users and updated ${registration.updatedCount} existing employees from Slack messages.`);
+    }
+
+    if (!SHOULD_ANALYZE_PROFILES) {
+        if (registration.changedCount > 0) {
+            fs.writeFileSync(DATA_FILE, JSON.stringify(employees, null, 2));
+            console.log(`Saved ${registration.changedCount} Slack user registrations to ${DATA_FILE}.`);
+            generateTeamDoc(employees);
+        } else {
+            console.log('Profile analysis skipped and no employee registrations were needed.');
+        }
+        return;
     }
 
     const targetEmployees = employees.filter(e => e.isActive !== false && (e.slack_id || e.slack_id_2));
@@ -177,6 +199,14 @@ async function main() {
     }
 }
 
+function optionValue(name) {
+    const prefix = `--${name}=`;
+    const inline = args.find(argument => argument.startsWith(prefix));
+    if (inline) return inline.slice(prefix.length);
+    const index = args.indexOf(`--${name}`);
+    return index >= 0 ? args[index + 1] : '';
+}
+
 async function registerSlackUsersFromMessages(employees, messages) {
     const knownSlackIds = new Set(employees.flatMap(e => [e.slack_id, e.slack_id_2]).filter(Boolean));
     const employeeByName = new Map(employees.map(employee => [normalizeEmployeeName(employee.name), employee]));
@@ -238,6 +268,7 @@ function collectSlackUserCandidates(messages, knownSlackIds) {
     for (const message of messages) {
         const userId = message.user;
         if (!userId || knownSlackIds.has(userId)) continue;
+        if (!/^[UW][A-Z0-9]+$/.test(userId)) continue;
 
         const workspace = message.workspace === 'secondary' ? 'secondary' : 'primary';
         const key = `${workspace}:${userId}`;


### PR DESCRIPTION
## 概要
- Slack同期で社員プロファイルAI分析をスキップできる `--profile-analysis=none` を追加しました
- 未登録者全員と未登録メッセージを軽量に反映する手動ワークフローを追加しました
- bot IDらしき投稿者は社員登録候補から除外します

## ブランチ・PR戦略
- ベースブランチ: main
- 作業ブランチ: codex/lightweight-unregistered-slack-sync-20260528
- PRサイズ目安: 軽量反映に必要なworkflow追加と同期スクリプト変更のみに限定
- 分割基準: Slack取得差分化やfull refresh分離は後続PR
- PR作成タイミング: ローカル構文確認と登録fixture検証後

## 検証
- node --check scripts/sync-slack.js
- registerSlackUsersFromMessages のfixture検証
- git diff --check

## 残リスク
- 実データ反映は、このPRをマージ後に Lightweight Slack Reflect を手動実行して行います
