### PR TITLE
軽量Slack反映後にPagesも同時デプロイする

### DIFF
--- a/.github/workflows/slack-lightweight-reflect.yml
+++ b/.github/workflows/slack-lightweight-reflect.yml
@@ -11,8 +11,13 @@ on:
 jobs:
   reflect:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     permissions:
       contents: write
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -59,3 +64,15 @@ jobs:
             git commit -m "Auto: Reflect Slack users and messages"
             git push
           fi
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## 概要
- `Lightweight Slack Reflect` の同一 workflow 内で GitHub Pages をデプロイするようにしました。
- Actions の `GITHUB_TOKEN` で push されたコミットは別 workflow の push トリガーを起動しないため、`docs/slack-export` 更新後に Pages が自動反映されない問題を潰します。

## ブランチ・PR戦略
- ベースブランチ: `main`
- 作業ブランチ: `codex/lightweight-pages-deploy-20260528`
- PR サイズ目安: workflow 1ファイルのみ、約20行以内
- 分割基準: Slack同期処理本体や検索ロジック変更は含めず、Pages公開連携のみを対象
- PR作成タイミング: 軽量反映 workflow の成功後、Pages自動追随の欠落を確認したため即時作成

## 検証
- `git diff --check`
- 手動で `Deploy to GitHub Pages` を起動し、run `26574282053` が成功することを確認
- 公開URL `https://saitekiinc-com.github.io/saiteki-employee-management/slack-export/` が HTTP 200 を返すことを確認

## 残リスク
- 次回の軽量反映 workflow で同居した Pages デプロイ手順が初回実行されるまでは、workflow 内デプロイ自体の本番実行結果は未確認です。
