### PR TITLE
未登録Slackデータを検索出力を変えずにPages反映する

### DIFF
--- a/.github/workflows/slack-registry-pages.yml
+++ b/.github/workflows/slack-registry-pages.yml
@@ -1,0 +1,84 @@
+name: Slack Registry and Pages Reflect
+
+on:
+  workflow_dispatch:
+    inputs:
+      full_sync:
+        description: '全期間の履歴を取得しますか？'
+        type: boolean
+        default: false
+
+jobs:
+  reflect:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Sync Slack registry data
+        run: |
+          if [ "${{ github.event.inputs.full_sync }}" = "true" ]; then
+            node scripts/sync-slack.js --registry-only --full
+          else
+            node scripts/sync-slack.js --registry-only
+          fi
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN || secrets.SLACK_APP_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_BOT_TOKEN_2: ${{ secrets.SLACK_BOT_TOKEN_2 }}
+          SLACK_CHANNEL_ID_2: ${{ secrets.SLACK_CHANNEL_ID_2 }}
+
+      - name: Build Slack Export Pages
+        run: npm run build:slack-export-pages
+
+      - name: Guard search output stability
+        run: |
+          git diff --exit-code -- \
+            data/knowledge-graph.json \
+            data/search-facets.jsonld \
+            data/profile-search-index.json \
+            data/profile-search-index.embedded.json \
+            data/message-search-index.json \
+            data/message-search-index.embedded.json \
+            docs/TEAM.md \
+            docs/KNOWLEDGE_GRAPH.md \
+            docs/index.html \
+            workers/slack-people-finder/src/index.js
+
+      - name: Commit and Push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add data/employees.json data/slack-messages.jsonl docs/slack-export
+          if git diff --staged --quiet; then
+            echo "No Slack registry or Pages changes to commit"
+          else
+            git commit -m "Auto: Reflect Slack registry and Pages"
+            git push
+          fi
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:message-vector": "node scripts/test-message-vector-search.js",
     "test:profile-search-index": "node scripts/test-profile-search-index.js",
     "test:profile-vector-search": "node scripts/test-profile-vector-search.js",
+    "test:slack-registry-normalization": "node scripts/test-slack-registry-normalization.js",
     "test:people-finder-rerank": "node scripts/test-people-finder-rerank.js",
     "test:people-finder": "node scripts/test-people-finder-rag-search.js"
   },

--- a/scripts/build-search-facets.js
+++ b/scripts/build-search-facets.js
@@ -217,32 +217,68 @@ function messageKey(message) {
   return `${message.workspace || 'primary'}:${message.channelId || message.channel || ''}:${message.ts || message.messageTs || ''}`;
 }
 
-function normalizeSlackMessage(message, workspace = 'primary') {
-  const text = cleanText(message.text, 2000);
-  if (!message.user || !message.ts || !text) return null;
+function normalizeSlackMessage(message, workspace = 'primary', context = {}) {
+  const text = cleanText(message.text || message.rawText, 2000);
+  const messageTs = String(message.messageTs || message.ts || '');
+  const channelId = message.channelId || message.channel || '';
+  const timestamp = message.timestamp || timestampFromSlackTs(messageTs);
+  if (!message.user || !messageTs || !text) return null;
   return {
     id: messageKey({ ...message, workspace }),
     workspace,
-    channelId: message.channelId || message.channel || '',
+    channelId,
+    channelName: message.channelName || context.channelNameById?.get(channelId) || '',
     user: message.user,
+    userName: message.userName || message.username || context.userNameById?.get(message.user) || '',
+    userRealName: message.userRealName || context.userRealNameById?.get(message.user) || '',
     text,
-    messageTs: String(message.ts),
-    threadTs: message.thread_ts ? String(message.thread_ts) : null,
-    parentUserId: message.parent_user_id || null,
+    rawText: message.rawText || message.text || '',
+    messageTs,
+    threadTs: message.threadTs ? String(message.threadTs) : (message.thread_ts ? String(message.thread_ts) : null),
+    parentUserId: message.parentUserId || message.parent_user_id || null,
+    subtype: message.subtype || null,
+    date: message.date || timestamp.slice(0, 10),
+    timestamp,
+    source: message.source || 'slack_api',
+    sourceFile: message.sourceFile || '',
     permalink: message.permalink || null
   };
 }
 
 function mergeSlackMessages(existingRows, fetchedMessages) {
   const rowsById = new Map();
+  const context = buildSlackMessageContext(existingRows);
   for (const row of existingRows) {
     if (row && row.id) rowsById.set(row.id, row);
   }
   for (const message of fetchedMessages) {
-    const row = normalizeSlackMessage(message, message.workspace || 'primary');
+    const row = normalizeSlackMessage(message, message.workspace || 'primary', context);
     if (row) rowsById.set(row.id, row);
   }
   return [...rowsById.values()].sort((a, b) => (a.messageTs || '').localeCompare(b.messageTs || ''));
+}
+
+function buildSlackMessageContext(rows) {
+  const channelNameById = new Map();
+  const userNameById = new Map();
+  const userRealNameById = new Map();
+  for (const row of rows || []) {
+    if (row.channelId && row.channelName && !channelNameById.has(row.channelId)) {
+      channelNameById.set(row.channelId, row.channelName);
+    }
+    if (row.user && row.userName && !userNameById.has(row.user)) {
+      userNameById.set(row.user, row.userName);
+    }
+    if (row.user && row.userRealName && !userRealNameById.has(row.user)) {
+      userRealNameById.set(row.user, row.userRealName);
+    }
+  }
+  return { channelNameById, userNameById, userRealNameById };
+}
+
+function timestampFromSlackTs(messageTs) {
+  const millis = Number.parseFloat(messageTs || '0') * 1000;
+  return Number.isFinite(millis) && millis > 0 ? new Date(millis).toISOString() : '';
 }
 
 function messagesBySlackId(messages) {
@@ -460,6 +496,7 @@ if (require.main === module) {
 
 module.exports = {
   buildSearchFacets,
+  buildSlackMessageContext,
   mergeSlackMessages,
   normalizeSlackMessage,
   readJsonl,

--- a/scripts/sync-slack.js
+++ b/scripts/sync-slack.js
@@ -24,10 +24,16 @@ const ENDPOINT_ID = process.env.GCP_ENDPOINT_ID;
 // Parse command line arguments
 const args = process.argv.slice(2);
 const IS_FULL_SYNC = args.includes('--full');
+const IS_REGISTRY_ONLY = args.includes('--registry-only');
 
 
 async function main() {
-    if (!SLACK_TOKEN || CHANNEL_IDS.length === 0 || !API_KEY || !PROJECT_ID) {
+    if (!SLACK_TOKEN || CHANNEL_IDS.length === 0) {
+        console.error('Missing required environment variables: SLACK_BOT_TOKEN, SLACK_CHANNEL_ID');
+        process.exit(1);
+    }
+
+    if (!IS_REGISTRY_ONLY && (!API_KEY || !PROJECT_ID)) {
         console.error('Missing required environment variables: SLACK_BOT_TOKEN, SLACK_CHANNEL_ID, GEMINI_API_KEY, GCP_PROJECT_ID');
         process.exit(1);
     }
@@ -43,7 +49,7 @@ async function main() {
 
     const employees = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
 
-    console.log(`Starting sync... Full Mode: ${IS_FULL_SYNC}`);
+    console.log(`Starting sync... Full Mode: ${IS_FULL_SYNC}, Registry Only: ${IS_REGISTRY_ONLY}`);
     console.log(`Target Channels: ${CHANNEL_IDS.join(', ')}`);
 
     // Fetch messages from ALL channels (Primary Workspace)
@@ -88,12 +94,25 @@ async function main() {
 
     const existingSlackMessages = readJsonl(SLACK_MESSAGES_FILE);
     const mergedSlackMessages = mergeSlackMessages(existingSlackMessages, [...allMessages, ...allMessages2]);
-    writeJsonl(SLACK_MESSAGES_FILE, mergedSlackMessages);
-    console.log(`Saved ${mergedSlackMessages.length} normalized Slack messages to ${SLACK_MESSAGES_FILE}.`);
 
     const registration = await registerSlackUsersFromMessages(employees, mergedSlackMessages);
     if (registration.changedCount > 0) {
         console.log(`Registered ${registration.createdCount} new Slack users and updated ${registration.updatedCount} existing employees from Slack messages.`);
+    }
+
+    const enrichedSlackMessages = enrichSlackMessageAuthors(mergedSlackMessages, employees, registration.userProfilesByKey);
+    writeJsonl(SLACK_MESSAGES_FILE, enrichedSlackMessages);
+    console.log(`Saved ${enrichedSlackMessages.length} normalized Slack messages to ${SLACK_MESSAGES_FILE}.`);
+
+    if (IS_REGISTRY_ONLY) {
+        if (registration.changedCount > 0) {
+            fs.writeFileSync(DATA_FILE, JSON.stringify(employees, null, 2));
+            console.log(`Saved ${registration.changedCount} Slack user registrations to ${DATA_FILE}.`);
+        } else {
+            console.log('No Slack user registration updates performed.');
+        }
+        console.log('Registry-only mode finished without AI profile analysis or search index generation.');
+        return;
     }
 
     const targetEmployees = employees.filter(e => e.isActive !== false && (e.slack_id || e.slack_id_2));
@@ -181,6 +200,7 @@ async function registerSlackUsersFromMessages(employees, messages) {
     const knownSlackIds = new Set(employees.flatMap(e => [e.slack_id, e.slack_id_2]).filter(Boolean));
     const employeeByName = new Map(employees.map(employee => [normalizeEmployeeName(employee.name), employee]));
     const candidates = collectSlackUserCandidates(messages, knownSlackIds);
+    const userProfilesByKey = new Map();
     let createdCount = 0;
     let updatedCount = 0;
 
@@ -188,6 +208,7 @@ async function registerSlackUsersFromMessages(employees, messages) {
         const field = candidate.workspace === 'secondary' ? 'slack_id_2' : 'slack_id';
         const token = candidate.workspace === 'secondary' ? SLACK_TOKEN_2 : SLACK_TOKEN;
         const user = token ? await fetchSlackUserInfo(candidate.userId, token) : null;
+        if (user) userProfilesByKey.set(`${candidate.workspace}:${candidate.userId}`, user);
         if (user && !isEligibleSlackUser(user)) continue;
 
         const name = slackUserName(user) || candidate.userRealName || candidate.userName;
@@ -229,7 +250,8 @@ async function registerSlackUsersFromMessages(employees, messages) {
     return {
         createdCount,
         updatedCount,
-        changedCount: createdCount + updatedCount
+        changedCount: createdCount + updatedCount,
+        userProfilesByKey
     };
 }
 
@@ -238,6 +260,7 @@ function collectSlackUserCandidates(messages, knownSlackIds) {
     for (const message of messages) {
         const userId = message.user;
         if (!userId || knownSlackIds.has(userId)) continue;
+        if (!/^[UW][A-Z0-9]+$/.test(userId)) continue;
 
         const workspace = message.workspace === 'secondary' ? 'secondary' : 'primary';
         const key = `${workspace}:${userId}`;
@@ -253,6 +276,37 @@ function collectSlackUserCandidates(messages, knownSlackIds) {
         byUser.set(key, current);
     }
     return [...byUser.values()];
+}
+
+function enrichSlackMessageAuthors(messages, employees, userProfilesByKey = new Map()) {
+    const nameByKey = new Map();
+    const realNameByKey = new Map();
+
+    for (const employee of employees) {
+        if (employee.slack_id) {
+            nameByKey.set(`primary:${employee.slack_id}`, employee.name);
+        }
+        if (employee.slack_id_2) {
+            nameByKey.set(`secondary:${employee.slack_id_2}`, employee.name);
+        }
+    }
+
+    for (const [key, user] of userProfilesByKey.entries()) {
+        const name = slackUserName(user);
+        if (name) nameByKey.set(key, name);
+        const realName = user.real_name || user.profile?.real_name || '';
+        if (realName) realNameByKey.set(key, realName);
+    }
+
+    return messages.map((message) => {
+        const workspace = message.workspace === 'secondary' ? 'secondary' : 'primary';
+        const key = `${workspace}:${message.user}`;
+        return {
+            ...message,
+            userName: message.userName || nameByKey.get(key) || message.user || '',
+            userRealName: message.userRealName || realNameByKey.get(key) || nameByKey.get(key) || ''
+        };
+    });
 }
 
 function slackUserName(user) {

--- a/scripts/test-slack-registry-normalization.js
+++ b/scripts/test-slack-registry-normalization.js
@@ -1,0 +1,84 @@
+const assert = require('assert');
+
+const {
+  mergeSlackMessages,
+  normalizeSlackMessage
+} = require('./build-search-facets');
+const {
+  collectSlackUserCandidates,
+  registerSlackUsersFromMessages
+} = require('./sync-slack');
+
+const existing = [
+  {
+    id: 'primary:C123:100.000001',
+    workspace: 'primary',
+    channelId: 'C123',
+    channelName: '自己紹介',
+    user: 'UKNOWN',
+    userName: '既存 太郎',
+    userRealName: '既存 太郎',
+    text: '既存メッセージ',
+    rawText: '既存メッセージ',
+    messageTs: '100.000001',
+    date: '2026-01-01',
+    timestamp: '2026-01-01T00:00:00.001Z',
+    source: 'slack_export'
+  }
+];
+
+const normalized = normalizeSlackMessage({
+  workspace: 'primary',
+  channelId: 'C123',
+  channel: 'C123',
+  user: 'UNEWUSER01',
+  text: 'ホラーゲームにハマっています。',
+  ts: '200.000002'
+}, 'primary', {
+  channelNameById: new Map([['C123', '自己紹介']]),
+  userNameById: new Map([['UNEWUSER01', '新規 太郎']]),
+  userRealNameById: new Map([['UNEWUSER01', '新規 太郎']])
+});
+
+assert.strictEqual(normalized.channelName, '自己紹介');
+assert.strictEqual(normalized.userName, '新規 太郎');
+assert.strictEqual(normalized.source, 'slack_api');
+assert.strictEqual(normalized.date, '1970-01-01');
+
+const merged = mergeSlackMessages(existing, [
+  {
+    workspace: 'primary',
+    channelId: 'C123',
+    user: 'UNEWUSER01',
+    text: 'ゲーセンが好きです。',
+    ts: '300.000003'
+  }
+]);
+const added = merged.find((message) => message.user === 'UNEWUSER01');
+assert.strictEqual(added.channelName, '自己紹介');
+assert.strictEqual(added.source, 'slack_api');
+
+const candidates = collectSlackUserCandidates([
+  { workspace: 'primary', user: 'UNEWUSER01', userName: '新規 太郎' },
+  { workspace: 'primary', user: 'B123BOT', userName: 'bot' },
+  { workspace: 'primary', user: 'UKNOWN', userName: '既存 太郎' }
+], new Set(['UKNOWN']));
+assert.deepStrictEqual(candidates.map((candidate) => candidate.userId), ['UNEWUSER01']);
+
+(async () => {
+  const employees = [];
+  const result = await registerSlackUsersFromMessages(employees, [
+    {
+      workspace: 'primary',
+      user: 'UNEWUSER01',
+      userName: '新規 太郎',
+      text: '自己紹介です。'
+    }
+  ]);
+  assert.strictEqual(result.createdCount, 1);
+  assert.strictEqual(employees[0].name, '新規 太郎');
+  console.log('slack registry normalization OK');
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要
- Slack同期に `--registry-only` を追加し、未登録社員と未登録メッセージだけを反映できるようにしました。
- Slack API由来メッセージでも `channelName` / `userName` / `date` / `timestamp` / `source` などを保持するように正規化を改善しました。
- `Slack Registry and Pages Reflect` workflowを追加し、`employees.json` / `slack-messages.jsonl` / `docs/slack-export` だけを更新・Pagesデプロイします。
- workflow内に検索出力安定ガードを入れ、search index、profile index、facets、TEAM、Workerが変わった場合は失敗するようにしました。

## ブランチ・PR戦略
- ベースブランチ: `main`
- 作業ブランチ: `codex/register-slack-data-with-stable-output-20260528`
- PRサイズ目安: 約300行以内
- 分割基準: Workerの検索品質改善や回答生成変更は含めず、登録とPages反映だけに限定
- PR作成タイミング: 既存検索テストと新規正規化テスト完了後

## 生成テキスト・挙動を変えないための条件
- `workers/slack-people-finder/src/index.js` は変更しません。
- `data/message-search-index*.json`、`data/profile-search-index*.json`、`data/search-facets.jsonld` はこのworkflowで更新しません。
- `docs/TEAM.md`、`docs/KNOWLEDGE_GRAPH.md`、`docs/index.html` もこのworkflowで更新しません。
- workflowの `Guard search output stability` で、上記が変わった場合はコミット前に止めます。

## 検証
- `node --check scripts/sync-slack.js`
- `node --check scripts/build-search-facets.js`
- `node --check scripts/test-slack-registry-normalization.js`
- `npm run test:slack-registry-normalization`
- `npm run test:message-vector`
- `npm run test:people-finder-rerank`
- `npm run test:people-finder`
- `npm run test:profile-vector-search`
- `npm run test:profile-search-index`
- `git diff --check`

## 残リスク
- このPRでは検索indexを更新しないため、BOTの検索結果には新規メッセージはまだ反映されません。Pagesと登録データだけを安全に最新化します。
- 検索への反映は、計画書に沿って候補品質ゲートとfallback安全化を入れた後に別PRで行います。
