### PR TITLE
People Finderの回答生成失敗理由をログ化する

### DIFF
--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -348,7 +348,7 @@ async function searchPeopleAnswer(env, query, categoryResolution) {
         })
       };
     } catch (error) {
-      console.error('People answer generation failed', error);
+      console.error('People answer generation failed', answerGenerationErrorDetails(error));
       return {
         blocks: answerMessageBlocks({
           query,
@@ -1277,23 +1277,103 @@ function defaultRejectEvidence(relationIntent) {
 
 async function generatePeopleAnswer(env, query, category, plan, candidates) {
   const model = env.GEMINI_RERANK_MODEL || DEFAULT_RERANK_MODEL;
-  const data = await callGemini(env, model, 'generateContent', {
-    contents: [
-      {
-        role: 'user',
-        parts: [{ text: buildAnswerPrompt(query, category, plan, candidates) }]
-      }
-    ],
-    generationConfig: {
-      temperature: 0,
-      responseMimeType: 'application/json'
-    }
-  });
-  const parsed = parseJsonText(geminiText(data));
-  return {
-    answer: String(parsed.answer || '').trim() || '回答を生成できませんでした。',
-    selected: Array.isArray(parsed.selected) ? parsed.selected : []
+  const prompt = buildAnswerPrompt(query, category, plan, candidates);
+  const startedAt = Date.now();
+  const baseDiagnostics = {
+    model,
+    category,
+    relationIntent: plan?.relationIntent || '',
+    candidateCount: candidates.length,
+    promptChars: prompt.length
   };
+  console.log('People answer generation started', baseDiagnostics);
+
+  let data;
+  try {
+    data = await callGemini(env, model, 'generateContent', {
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: prompt }]
+        }
+      ],
+      generationConfig: {
+        temperature: 0,
+        responseMimeType: 'application/json'
+      }
+    });
+  } catch (error) {
+    throw attachAnswerDiagnostics(error, {
+      ...baseDiagnostics,
+      stage: 'gemini_generate_content',
+      elapsedMs: Date.now() - startedAt
+    });
+  }
+
+  const text = geminiText(data);
+  let parsed;
+  try {
+    parsed = parseJsonText(text);
+  } catch (error) {
+    throw attachAnswerDiagnostics(error, {
+      ...baseDiagnostics,
+      stage: 'parse_json',
+      elapsedMs: Date.now() - startedAt,
+      responseChars: text.length,
+      finishReasons: geminiFinishReasons(data)
+    });
+  }
+
+  const answer = String(parsed.answer || '').trim();
+  const selected = Array.isArray(parsed.selected) ? parsed.selected : [];
+  if (!answer) {
+    console.warn('People answer generation returned empty answer', {
+      ...baseDiagnostics,
+      stage: 'empty_answer',
+      elapsedMs: Date.now() - startedAt,
+      responseChars: text.length,
+      selectedCount: selected.length,
+      finishReasons: geminiFinishReasons(data)
+    });
+  } else {
+    console.log('People answer generation completed', {
+      ...baseDiagnostics,
+      elapsedMs: Date.now() - startedAt,
+      responseChars: text.length,
+      answerChars: answer.length,
+      selectedCount: selected.length,
+      finishReasons: geminiFinishReasons(data)
+    });
+  }
+
+  return {
+    answer: answer || '回答を生成できませんでした。',
+    selected
+  };
+}
+
+function attachAnswerDiagnostics(error, diagnostics) {
+  if (error && typeof error === 'object') {
+    error.answerDiagnostics = {
+      ...(error.answerDiagnostics || {}),
+      ...diagnostics
+    };
+  }
+  return error;
+}
+
+function answerGenerationErrorDetails(error) {
+  return {
+    name: error?.name || 'Error',
+    message: truncate(error?.message || String(error), 500),
+    ...(error?.answerDiagnostics || {})
+  };
+}
+
+function geminiFinishReasons(data) {
+  return (data?.candidates || [])
+    .map((candidate) => candidate.finishReason)
+    .filter(Boolean);
 }
 
 function buildAnswerPrompt(query, category, plan, candidates) {


### PR DESCRIPTION
## 概要
- People Finder の `generatePeopleAnswer()` に、回答生成の開始・成功・失敗stageを切り分ける診断ログを追加します。
- 生成結果の表示やfallback挙動は変えず、メタ情報だけをログに出します。

## 目的
- fallback に落ちた時に、原因が `Gemini APIエラー` / `JSON parse失敗` / `空回答` / `時間超過` のどれかを切り分けられるようにします。
- 未登録者・未登録メッセージの再反映前に、回答生成失敗の原因を観測できる状態にします。

## ログに出す情報
- モデル名
- カテゴリ
- relationIntent
- 候補数
- プロンプト文字数
- elapsedMs
- Gemini応答文字数
- finishReason
- selected件数
- 失敗stage

本文や候補全文はログに出していません。

## 検証
- `node --check workers/slack-people-finder/src/index.js`
- `npm run test:people-finder-rerank`
- `npm run test:people-finder`
- `git diff --check`

## ブランチ・PR戦略
- ベースブランチ: `main`
- 作業ブランチ: `codex/people-finder-answer-diagnostics-20260528`
- PRサイズ目安: Workerの診断ログ追加のみの小PR
- 分割基準: 未登録データ再反映や回答生成改善は別PRに分けます。
- PR作成タイミング: 構文チェックと既存テスト通過後。

## 残リスク
- このPRは観測用であり、fallbackに落ちる根本原因そのものは修正しません。
