### PR TITLE
People Finderモーダル表示と失敗診断を安定化する

### DIFF
--- a/workers/slack-people-finder/src/index.js
+++ b/workers/slack-people-finder/src/index.js
@@ -93,11 +93,19 @@ async function handleSlashCommand(rawBody, env, ctx) {
   }
 
   if (query.trim()) {
-    ctx.waitUntil(openModal(env, triggerId, buildSearchModal({
-      channelId,
-      initialQuery: query.trim(),
-      initialCategory: resolveSearchCategory(query.trim(), '仕事・相談').category
-    })));
+    try {
+      await openModal(env, triggerId, buildSearchModal({
+        channelId,
+        initialQuery: query.trim(),
+        initialCategory: resolveSearchCategory(query.trim(), '仕事・相談').category
+      }));
+    } catch (error) {
+      console.error('Failed to open people finder modal from slash command', modalErrorDetails(error));
+      return slackJson({
+        response_type: 'ephemeral',
+        text: '社員検索モーダルの表示に失敗しました。少し時間を置いて再実行してください。'
+      });
+    }
   }
 
   return slackJson({
@@ -117,11 +125,15 @@ async function handleInteraction(rawBody, env, ctx) {
     const action = payload.actions?.[0];
     if (action?.action_id === OPEN_ACTION) {
       const actionValue = parseActionValue(action.value);
-      ctx.waitUntil(openModal(env, payload.trigger_id, buildSearchModal({
-        channelId: payload.channel?.id,
-        initialQuery: actionValue.initialQuery || '',
-        initialCategory: resolveSearchCategory(actionValue.initialQuery || '', actionValue.initialCategory || '仕事・相談').category
-      })));
+      try {
+        await openModal(env, payload.trigger_id, buildSearchModal({
+          channelId: payload.channel?.id,
+          initialQuery: actionValue.initialQuery || '',
+          initialCategory: resolveSearchCategory(actionValue.initialQuery || '', actionValue.initialCategory || '仕事・相談').category
+        }));
+      } catch (error) {
+        console.error('Failed to open people finder modal from block action', modalErrorDetails(error));
+      }
     }
     return new Response('', { status: 200 });
   }
@@ -1384,11 +1396,23 @@ function answerFailureDiagnosticsNote(env, error) {
     Number.isFinite(details.promptChars) ? `promptChars=${details.promptChars}` : '',
     Number.isFinite(details.responseChars) ? `responseChars=${details.responseChars}` : '',
     Number.isFinite(details.elapsedMs) ? `elapsedMs=${details.elapsedMs}` : '',
+    details.message ? `error=${diagnosticValue(details.message, 180)}` : '',
     Array.isArray(details.finishReasons) && details.finishReasons.length > 0
       ? `finishReasons=${details.finishReasons.join(',')}`
       : ''
   ].filter(Boolean);
   return parts.length > 0 ? `診断: ${parts.join(' / ')}` : '';
+}
+
+function diagnosticValue(value, maxLength = 180) {
+  return truncate(String(value || '').replace(/\s+/g, ' '), maxLength);
+}
+
+function modalErrorDetails(error) {
+  return {
+    name: error?.name || 'Error',
+    message: diagnosticValue(error?.message || String(error), 300)
+  };
 }
 
 function geminiFinishReasons(data) {


### PR DESCRIPTION
## 概要
- モーダル表示を `ctx.waitUntil` に逃がさず、`views.open` を実行してからSlackへ応答するようにします。
- モーダル表示失敗時のログを追加します。
- AI回答生成失敗の一時診断に、Gemini APIエラー本文の短縮版を追加します。

## 背景
- `/slack/interactions` は200で返っているのにモーダルが開かないケースがありました。
- `waitUntil` 内の `views.open` 失敗はユーザーにもログにも見えにくいため、モーダル表示だけは同期的に実行します。
- 回答生成失敗は `stage=gemini_generate_content` まで絞れたため、次にAPIエラー本文を確認できるようにします。

## 検証
- `node --check workers/slack-people-finder/src/index.js`
- `npm run test:people-finder-rerank`
- `npm run test:people-finder`
- `git diff --check`

## ブランチ・PR戦略
- ベースブランチ: `main`
- 作業ブランチ: `codex/fix-modal-open-20260528`
- PRサイズ目安: Workerの小修正のみ
- 分割基準: Gemini API失敗の根本修正は診断結果確認後に別PRで行います。
- PR作成タイミング: 検証通過後。

## 残リスク
- Slash commandで即モーダルを開く場合、Slack API呼び出し分だけ応答が遅くなります。ただし通常は3秒制限内に収まる想定です。
