### PR TITLE
Slack軽量反映を日次実行にする

### DIFF
--- a/.github/workflows/slack-registry-pages.yml
+++ b/.github/workflows/slack-registry-pages.yml
@@ -1,12 +1,19 @@
 name: Slack Registry and Pages Reflect
 
 on:
+  schedule:
+    # 毎日午前9時 (JST) = UTC 0:00。Slack登録者・メッセージ・Pagesだけを軽量反映する。
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       full_sync:
         description: '全期間の履歴を取得しますか？'
         type: boolean
         default: false
+
+concurrency:
+  group: slack-registry-pages-reflect
+  cancel-in-progress: false
 
 jobs:
   reflect:
@@ -42,7 +49,19 @@ jobs:
           SLACK_BOT_TOKEN_2: ${{ secrets.SLACK_BOT_TOKEN_2 }}
           SLACK_CHANNEL_ID_2: ${{ secrets.SLACK_CHANNEL_ID_2 }}
 
+      - name: Detect Slack data changes
+        id: data_changes
+        run: |
+          if git diff --quiet -- data/employees.json data/slack-messages.jsonl; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No Slack registry or message changes detected"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Slack registry or message changes detected"
+          fi
+
       - name: Build Slack Export Pages
+        if: steps.data_changes.outputs.changed == 'true'
         run: npm run build:slack-export-pages
 
       - name: Guard search output stability
@@ -60,6 +79,7 @@ jobs:
             workers/slack-people-finder/src/index.js
 
       - name: Commit and Push changes
+        if: steps.data_changes.outputs.changed == 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -72,13 +92,16 @@ jobs:
           fi
 
       - name: Setup Pages
+        if: steps.data_changes.outputs.changed == 'true'
         uses: actions/configure-pages@v4
 
       - name: Upload Pages artifact
+        if: steps.data_changes.outputs.changed == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: './docs'
 
       - name: Deploy to GitHub Pages
+        if: steps.data_changes.outputs.changed == 'true'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/slack-sync-cron.yml
+++ b/.github/workflows/slack-sync-cron.yml
@@ -1,9 +1,6 @@
-name: Periodic Slack Sync
+name: Manual Full Slack Sync
 
 on:
-  schedule:
-    # 毎週月曜日の午前9時 (JST) = UTC 0:00
-    - cron: '0 0 * * 1'
   workflow_dispatch:
     inputs:
       full_sync:


### PR DESCRIPTION
## 概要
- `Slack Registry and Pages Reflect` を毎日9:00 JSTに自動実行するようにします。
- 日次実行は `--registry-only` のままなので、Slack登録者・メッセージ・Pagesだけを軽量反映します。
- Slackデータに差分がない日は、Pages build / commit / deploy をスキップします。
- 重い `Periodic Slack Sync` は `Manual Full Slack Sync` に変更し、全体再生成は手動実行に寄せます。

## 変更内容
- `.github/workflows/slack-registry-pages.yml`
  - daily schedule追加: `0 0 * * *`（JST 9:00）
  - concurrency追加
  - `data/employees.json` / `data/slack-messages.jsonl` に差分がない場合はPages関連stepをskip
- `.github/workflows/slack-sync-cron.yml`
  - weekly scheduleを削除
  - workflow名を手動実行前提に変更

## 期待する動き
- 毎日: 登録者・Slackメッセージ・Pagesだけを軽く更新
- 必要時のみ手動: ナレッジグラフ、検索facet、profile/message index、embedding、docsを全体再生成

## 検証
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/slack-registry-pages.yml .github/workflows/slack-sync-cron.yml`
- `git diff --check`

## ブランチ・PR戦略
- ベースブランチ: `main`
- 作業ブランチ: `codex/daily-light-slack-reflect-20260528`
- PRサイズ目安: workflowのみの小PR
- 分割基準: index差分更新やAI消費削減は別PRに分けます。
- PR作成タイミング: YAML確認後。

## 残リスク
- 検索インデックスは日次では更新されません。追加メッセージをBOTのベクトル検索対象に入れるには、別途message indexの差分更新が必要です。
