### PR TITLE
日次Slack反映でmessage search indexも更新する

### DIFF
--- a/.github/workflows/slack-registry-pages.yml
+++ b/.github/workflows/slack-registry-pages.yml
@@ -2,7 +2,7 @@ name: Slack Registry and Pages Reflect
 
 on:
   schedule:
-    # 毎日午前9時 (JST) = UTC 0:00。Slack登録者・メッセージ・Pagesだけを軽量反映する。
+    # 毎日午前9時 (JST) = UTC 0:00。Slack社員検索に必要なメッセージindexまで軽量反映する。
     - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
@@ -60,6 +60,16 @@ jobs:
             echo "Slack registry or message changes detected"
           fi
 
+      - name: Build Message Search Index
+        if: steps.data_changes.outputs.changed == 'true'
+        run: npm run build:message-search-index
+
+      - name: Embed Message Search Index
+        if: steps.data_changes.outputs.changed == 'true'
+        run: npm run embed:message-search-index
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
       - name: Build Slack Export Pages
         if: steps.data_changes.outputs.changed == 'true'
         run: npm run build:slack-export-pages
@@ -71,8 +81,6 @@ jobs:
             data/search-facets.jsonld \
             data/profile-search-index.json \
             data/profile-search-index.embedded.json \
-            data/message-search-index.json \
-            data/message-search-index.embedded.json \
             docs/TEAM.md \
             docs/KNOWLEDGE_GRAPH.md \
             docs/index.html \
@@ -83,7 +91,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add data/employees.json data/slack-messages.jsonl docs/slack-export
+          git add data/employees.json data/slack-messages.jsonl data/message-search-index.json data/message-search-index.embedded.json docs/slack-export
           if git diff --staged --quiet; then
             echo "No Slack registry or Pages changes to commit"
           else


### PR DESCRIPTION
## 概要
- 日次の `Slack Registry and Pages Reflect` に、Slack社員検索で実際に使う message search index の更新を追加します。
- Slackデータに差分がある場合だけ `message-search-index` を build/embed します。
- ナレッジグラフ、search facets、profile index は日次更新対象に含めません。

## 更新対象
日次で差分がある場合に更新されるファイル:
- `data/employees.json`
- `data/slack-messages.jsonl`
- `data/message-search-index.json`
- `data/message-search-index.embedded.json`
- `docs/slack-export/`

日次では更新しないファイル:
- `data/knowledge-graph.json`
- `data/search-facets.jsonld`
- `data/profile-search-index.json`
- `data/profile-search-index.embedded.json`
- `docs/TEAM.md`
- `docs/KNOWLEDGE_GRAPH.md`
- `docs/index.html`
- Workerコード

## 軽量性
- `embed-profile-search-index.js` は既存のembedded indexを読み、同じunit idかつ本文hashが同じembeddingを再利用します。
- そのため、日次のembedding生成は基本的に新規・変更メッセージ分だけになります。

## 検証
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/slack-registry-pages.yml"); puts "OK"'`
- `git diff --check`
- `npm run test:message-vector`

## ブランチ・PR戦略
- ベースブランチ: `main`
- 作業ブランチ: `codex/daily-message-index-refresh-20260529`
- PRサイズ目安: workflowのみの小PR
- 分割基準: 未使用ファイルのarchive整理やprofile index日次化は別PRに分けます。
- PR作成タイミング: workflow構文とmessage vectorテスト通過後。

## 残リスク
- `GEMINI_API_KEY` のembedding quotaが不足している場合、日次のembed stepで失敗する可能性があります。
- profile fallbackは無効のままなので、profile indexは日次更新されません。
